### PR TITLE
Fix save selection and branch progression recovery

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,10 +2,12 @@ import os
 import random
 import json
 from datetime import datetime
+from pathlib import Path
 
 from dotenv import load_dotenv
 from flask import Flask, render_template, request, redirect, url_for, session, jsonify, flash
 from sqlalchemy import inspect, text
+from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.security import generate_password_hash, check_password_hash
 
 from models import db, User, SaveData, Friend, Message, FriendRequest
@@ -15,6 +17,8 @@ load_dotenv()
 app = Flask(__name__, instance_relative_config=True)
 
 os.makedirs(app.instance_path, exist_ok=True)
+SAVE_FALLBACK_DIR = Path(app.instance_path) / "save_fallbacks"
+SAVE_FALLBACK_DIR.mkdir(exist_ok=True)
 
 secret_key = os.environ.get("SECRET_KEY")
 if not secret_key:
@@ -48,8 +52,15 @@ def ensure_save_data_schema():
 
 
 with app.app_context():
-    db.create_all()
-    ensure_save_data_schema()
+    try:
+        db.create_all()
+        ensure_save_data_schema()
+    except SQLAlchemyError as error:
+        db.session.rollback()
+        app.logger.warning(
+            "Database initialization skipped because SQLite is unavailable. %s",
+            getattr(error, "orig", error)
+        )
 
 def get_friends(user_id):
     friendships = Friend.query.filter_by(user_id=user_id, status="accepted").all()
@@ -101,36 +112,224 @@ def get_user_save(character_id=None, create=False):
     return save_data
 
 
+def coerce_int(value, default=0):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def coerce_bool(value, default=False):
+    if value is None:
+        return default
+
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, (int, float)):
+        return bool(value)
+
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+
+    return bool(value)
+
+
+def build_save_payload_from_request(data, updated_at=None):
+    timestamp = updated_at or datetime.utcnow()
+
+    return {
+        "difficulty": str(data.get("difficulty", "EASY")).upper(),
+        "character_id": str(data.get("character_id", "leon")).lower(),
+        "health": coerce_int(data.get("health"), 100),
+        "medkits": coerce_int(data.get("medkits"), 0),
+        "grenades": coerce_int(data.get("grenades"), 0),
+        "ammo_in_gun": coerce_int(data.get("ammo_in_gun"), 0),
+        "ammo_in_bag": coerce_int(data.get("ammo_in_bag"), 0),
+        "mag_capacity": coerce_int(data.get("mag_capacity"), 8),
+        "laser_upgrade": coerce_bool(data.get("laser_upgrade"), False),
+        "shield_owned": coerce_bool(data.get("shield_owned"), False),
+        "shield_on": coerce_bool(data.get("shield_on"), False),
+        "current_level_id": str(data.get("current_level_id", "1")),
+        "enemies_remaining": coerce_int(data.get("enemies_remaining"), 0),
+        "level_complete": coerce_bool(data.get("level_complete"), False),
+        "awaiting_choice": coerce_bool(data.get("awaiting_choice"), False),
+        "game_won": coerce_bool(data.get("game_won"), False),
+        "has_started_game": True,
+        "kills": coerce_int(data.get("kills"), 0),
+        "damage_dealt": coerce_int(data.get("damage_dealt"), 0),
+        "damage_taken": coerce_int(data.get("damage_taken"), 0),
+        "pistol_shots": coerce_int(data.get("pistol_shots"), 0),
+        "grenades_used": coerce_int(data.get("grenades_used"), 0),
+        "medkits_used": coerce_int(data.get("medkits_used"), 0),
+        "reloads": coerce_int(data.get("reloads"), 0),
+        "knife_uses": coerce_int(data.get("knife_uses"), 0),
+        "run_state": data.get("run_state"),
+        "updated_at": timestamp.isoformat()
+    }
+
+
+def get_fallback_save_path(user_id, character_id):
+    safe_character = "".join(
+        char for char in str(character_id).lower()
+        if char.isalnum() or char in {"-", "_"}
+    ) or "leon"
+    return SAVE_FALLBACK_DIR / f"user_{user_id}_{safe_character}.json"
+
+
+def write_fallback_save(user_id, character_id, payload):
+    path = get_fallback_save_path(user_id, character_id)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def read_fallback_save(user_id, character_id):
+    path = get_fallback_save_path(user_id, character_id)
+
+    if not path.exists():
+        return None
+
+    try:
+        return normalize_save_payload(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def list_fallback_save_payloads(user_id):
+    pattern = f"user_{user_id}_*.json"
+    payloads = []
+
+    for path in SAVE_FALLBACK_DIR.glob(pattern):
+        try:
+            payload = normalize_save_payload(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        if payload is not None:
+            payloads.append(payload)
+
+    return payloads
+
+
+def parse_updated_at(value):
+    if not value:
+        return datetime.min
+
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError:
+        return datetime.min
+
+
+def normalize_save_payload(payload):
+    if not isinstance(payload, dict):
+        return None
+
+    normalized = dict(payload)
+    run_state = normalized.get("run_state")
+
+    if isinstance(run_state, dict):
+        player = run_state.get("player") or {}
+        inventory = run_state.get("inventory") or {}
+        progression = run_state.get("progression") or {}
+
+        if player.get("characterId") is not None:
+            normalized["character_id"] = str(player.get("characterId")).lower()
+
+        if inventory.get("health") is not None:
+            normalized["health"] = coerce_int(inventory.get("health"), normalized.get("health", 100))
+
+        if progression.get("currentLevelId") is not None:
+            normalized["current_level_id"] = str(progression.get("currentLevelId"))
+
+        if progression.get("enemiesRemaining") is not None:
+            normalized["enemies_remaining"] = coerce_int(
+                progression.get("enemiesRemaining"),
+                normalized.get("enemies_remaining", 0)
+            )
+
+        if progression.get("levelComplete") is not None:
+            normalized["level_complete"] = coerce_bool(
+                progression.get("levelComplete"),
+                normalized.get("level_complete", False)
+            )
+
+        if progression.get("awaitingChoice") is not None:
+            normalized["awaiting_choice"] = coerce_bool(
+                progression.get("awaitingChoice"),
+                normalized.get("awaiting_choice", False)
+            )
+
+        if progression.get("gameWon") is not None:
+            normalized["game_won"] = coerce_bool(
+                progression.get("gameWon"),
+                normalized.get("game_won", False)
+            )
+
+    normalized["difficulty"] = str(normalized.get("difficulty", "EASY")).upper()
+    normalized["character_id"] = str(normalized.get("character_id", "leon")).lower()
+    normalized["current_level_id"] = str(normalized.get("current_level_id", "1"))
+    normalized["health"] = coerce_int(normalized.get("health"), 100)
+    normalized["enemies_remaining"] = coerce_int(normalized.get("enemies_remaining"), 0)
+    normalized["level_complete"] = coerce_bool(normalized.get("level_complete"), False)
+    normalized["awaiting_choice"] = coerce_bool(normalized.get("awaiting_choice"), False)
+    normalized["game_won"] = coerce_bool(normalized.get("game_won"), False)
+    normalized["has_started_game"] = coerce_bool(normalized.get("has_started_game"), True)
+
+    return normalized
+
+
+def list_db_save_payloads(user_id, character_id=None):
+    query = SaveData.query.filter_by(user_id=user_id)
+
+    if character_id is not None:
+        query = query.filter_by(character_id=str(character_id).lower())
+
+    return [
+        normalize_save_payload(build_save_payload(save_data))
+        for save_data in query.all()
+        if save_data.has_started_game
+    ]
+
+
+def choose_latest_save_payload(*payloads):
+    candidates = [payload for payload in payloads if payload]
+
+    if not candidates:
+        return None
+
+    return max(candidates, key=lambda payload: parse_updated_at(payload.get("updated_at")))
+
+
 def update_save_data(save_data, data):
     save_data.difficulty = str(data.get("difficulty", save_data.difficulty or "EASY")).upper()
     save_data.character_id = str(data.get("character_id", save_data.character_id or "leon")).lower()
 
-    save_data.health = int(data.get("health", save_data.health))
-    save_data.medkits = int(data.get("medkits", save_data.medkits))
-    save_data.grenades = int(data.get("grenades", save_data.grenades))
+    save_data.health = coerce_int(data.get("health"), save_data.health)
+    save_data.medkits = coerce_int(data.get("medkits"), save_data.medkits)
+    save_data.grenades = coerce_int(data.get("grenades"), save_data.grenades)
 
-    save_data.ammo_in_gun = int(data.get("ammo_in_gun", save_data.ammo_in_gun))
-    save_data.ammo_in_bag = int(data.get("ammo_in_bag", save_data.ammo_in_bag))
-    save_data.mag_capacity = int(data.get("mag_capacity", save_data.mag_capacity))
+    save_data.ammo_in_gun = coerce_int(data.get("ammo_in_gun"), save_data.ammo_in_gun)
+    save_data.ammo_in_bag = coerce_int(data.get("ammo_in_bag"), save_data.ammo_in_bag)
+    save_data.mag_capacity = coerce_int(data.get("mag_capacity"), save_data.mag_capacity)
 
-    save_data.laser_upgrade = bool(data.get("laser_upgrade", save_data.laser_upgrade))
-    save_data.shield_owned = bool(data.get("shield_owned", save_data.shield_owned))
-    save_data.shield_on = bool(data.get("shield_on", save_data.shield_on))
+    save_data.laser_upgrade = coerce_bool(data.get("laser_upgrade"), save_data.laser_upgrade)
+    save_data.shield_owned = coerce_bool(data.get("shield_owned"), save_data.shield_owned)
+    save_data.shield_on = coerce_bool(data.get("shield_on"), save_data.shield_on)
 
     save_data.current_level_id = str(data.get("current_level_id", save_data.current_level_id))
-    save_data.enemies_remaining = int(data.get("enemies_remaining", save_data.enemies_remaining))
+    save_data.enemies_remaining = coerce_int(data.get("enemies_remaining"), save_data.enemies_remaining)
 
-    save_data.level_complete = bool(data.get("level_complete", save_data.level_complete))
-    save_data.awaiting_choice = bool(data.get("awaiting_choice", save_data.awaiting_choice))
-    save_data.game_won = bool(data.get("game_won", save_data.game_won))
-    save_data.kills = int(data.get("kills", save_data.kills))
-    save_data.damage_dealt = int(data.get("damage_dealt", save_data.damage_dealt))
-    save_data.damage_taken = int(data.get("damage_taken", save_data.damage_taken))
-    save_data.pistol_shots = int(data.get("pistol_shots", save_data.pistol_shots))
-    save_data.grenades_used = int(data.get("grenades_used", save_data.grenades_used))
-    save_data.medkits_used = int(data.get("medkits_used", save_data.medkits_used))
-    save_data.reloads = int(data.get("reloads", save_data.reloads))
-    save_data.knife_uses = int(data.get("knife_uses", save_data.knife_uses))
+    save_data.level_complete = coerce_bool(data.get("level_complete"), save_data.level_complete)
+    save_data.awaiting_choice = coerce_bool(data.get("awaiting_choice"), save_data.awaiting_choice)
+    save_data.game_won = coerce_bool(data.get("game_won"), save_data.game_won)
+    save_data.kills = coerce_int(data.get("kills"), save_data.kills)
+    save_data.damage_dealt = coerce_int(data.get("damage_dealt"), save_data.damage_dealt)
+    save_data.damage_taken = coerce_int(data.get("damage_taken"), save_data.damage_taken)
+    save_data.pistol_shots = coerce_int(data.get("pistol_shots"), save_data.pistol_shots)
+    save_data.grenades_used = coerce_int(data.get("grenades_used"), save_data.grenades_used)
+    save_data.medkits_used = coerce_int(data.get("medkits_used"), save_data.medkits_used)
+    save_data.reloads = coerce_int(data.get("reloads"), save_data.reloads)
+    save_data.knife_uses = coerce_int(data.get("knife_uses"), save_data.knife_uses)
     save_data.run_state_json = json.dumps(data.get("run_state")) if data.get("run_state") is not None else save_data.run_state_json
 
     save_data.has_started_game = True
@@ -198,6 +397,7 @@ def show_login():
         if not check_password_hash(user.password_hash, password):
             return render_template("login.html", error="Invalid username or password.")
 
+        session.clear()
         session["user_id"] = user.id
         session["username"] = user.username
         session["is_guest"] = False
@@ -244,7 +444,7 @@ def show_register():
 def guest_login():
     name = make_guest_name()
 
-    session.pop("user_id", None)
+    session.clear()
     session["username"] = name
     session["is_guest"] = True
 
@@ -257,6 +457,7 @@ def logout():
     return redirect(url_for("show_login"))
 
 
+@app.route("/main-menu")
 @app.route("/main_menu")
 def main_menu():
     username = session.get("username")
@@ -337,9 +538,42 @@ def save_game():
     character_id = str(data.get("character_id", "leon")).lower()
     session["selected_character"] = character_id
 
-    save_data = get_user_save(character_id=character_id, create=True)
-    update_save_data(save_data, data)
-    db.session.commit()
+    fallback_payload = build_save_payload_from_request(data)
+
+    try:
+        save_data = get_user_save(character_id=character_id, create=True)
+        update_save_data(save_data, data)
+        db.session.commit()
+    except SQLAlchemyError as error:
+        db.session.rollback()
+
+        try:
+            write_fallback_save(session["user_id"], character_id, fallback_payload)
+        except OSError:
+            app.logger.exception("Save failed for user %s.", session.get("user_id"))
+            return jsonify({
+                "ok": False,
+                "message": "Save failed."
+            }), 500
+
+        app.logger.warning(
+            "SQLite save failed for user %s; wrote fallback save instead. %s",
+            session.get("user_id"),
+            getattr(error, "orig", error)
+        )
+        return jsonify({
+            "ok": True,
+            "message": "Game saved locally."
+        })
+
+    try:
+        write_fallback_save(session["user_id"], character_id, build_save_payload(save_data))
+    except OSError as error:
+        app.logger.warning(
+            "Backup save write failed for user %s after database save succeeded. %s",
+            session.get("user_id"),
+            error
+        )
 
     return jsonify({
         "ok": True,
@@ -355,21 +589,43 @@ def load_game():
             "message": "Please log in to load your game."
         }), 401
 
-    character_id = request.args.get("character_id", session.get("selected_character", "leon")).lower()
-    session["selected_character"] = character_id
+    requested_character_id = request.args.get("character_id")
+    character_id = str(requested_character_id).lower() if requested_character_id else None
 
-    save_data = get_user_save(character_id=character_id)
+    db_payloads = []
+    fallback_payloads = []
 
-    if save_data is None or not save_data.has_started_game:
+    try:
+        db_payloads = list_db_save_payloads(session["user_id"], character_id=character_id)
+    except SQLAlchemyError as error:
+        db.session.rollback()
+        app.logger.warning(
+            "Database load failed for user %s; falling back to JSON save. %s",
+            session.get("user_id"),
+            getattr(error, "orig", error)
+        )
+
+    if character_id is not None:
+        fallback_payload = read_fallback_save(session["user_id"], character_id)
+        if fallback_payload is not None:
+            fallback_payloads.append(fallback_payload)
+    else:
+        fallback_payloads = list_fallback_save_payloads(session["user_id"])
+
+    save_payload = choose_latest_save_payload(*db_payloads, *fallback_payloads)
+
+    if save_payload is None:
         return jsonify({
             "ok": False,
             "message": "Start a new game first."
         })
 
+    session["selected_character"] = str(save_payload.get("character_id", "leon")).lower()
+
     return jsonify({
         "ok": True,
         "message": "Save loaded.",
-        "save_data": build_save_payload(save_data)
+        "save_data": save_payload
     })
 
 @app.route("/add_friend/<int:user_id>")

--- a/static/js/combat-engine.js
+++ b/static/js/combat-engine.js
@@ -436,6 +436,92 @@ function getCharacterPerk(state) {
   return CHARACTER_DEFS[state.player.characterId] || CHARACTER_DEFS.leon;
 }
 
+function levelHasChoices(level) {
+  return Boolean(
+    (Array.isArray(level?.choices) && level.choices.length > 0) ||
+    (Array.isArray(level?.choicePool) && level.choicePool.length > 0)
+  );
+}
+
+function repairProgressionState(state) {
+  const currentLevel = getCurrentLevelData(state);
+
+  if (!currentLevel) {
+    return;
+  }
+
+  const hasChoices = levelHasChoices(currentLevel);
+  const hasNextLevel = Boolean(currentLevel.next);
+
+  if (state.combat.inCombat && state.combat.enemy) {
+    state.progression.levelComplete = false;
+    state.progression.awaitingChoice = false;
+    state.progression.shopOpen = false;
+    state.progression.emergency = null;
+    state.progression.gameWon = false;
+  }
+
+  if (state.progression.emergency?.active) {
+    state.progression.levelComplete = false;
+    state.progression.awaitingChoice = false;
+    state.progression.shopOpen = false;
+    state.progression.gameWon = false;
+  }
+
+  if (hasChoices && state.progression.levelComplete && !state.progression.awaitingChoice) {
+    state.progression.awaitingChoice = true;
+  }
+
+  if (!hasChoices) {
+    state.progression.awaitingChoice = false;
+    state.progression.currentChoiceOptions = [];
+  }
+
+  if (state.progression.awaitingChoice) {
+    state.progression.levelComplete = true;
+    state.progression.gameWon = false;
+    state.combat.inCombat = false;
+    state.combat.enemy = null;
+
+    if (state.progression.currentChoiceOptions.length === 0) {
+      state.progression.currentChoiceOptions = pickChoiceOptions(currentLevel, createRng(state.rngSeed));
+    }
+  }
+
+  if (hasChoices || hasNextLevel) {
+    state.progression.gameWon = false;
+  }
+
+  if (state.progression.levelComplete) {
+    state.progression.enemiesRemaining = 0;
+  } else if (state.progression.encounterOrder.length > 0) {
+    state.progression.enemiesRemaining = Math.max(
+      state.progression.encounterOrder.length - state.progression.currentEncounterIndex,
+      state.combat.enemy ? 1 : 0
+    );
+  }
+
+  if (
+    !hasChoices &&
+    !hasNextLevel &&
+    state.progression.levelComplete &&
+    !state.progression.shopOpen &&
+    !state.progression.emergency?.active
+  ) {
+    state.progression.gameWon = true;
+  }
+
+  if (state.progression.gameWon) {
+    state.progression.levelComplete = true;
+    state.progression.awaitingChoice = false;
+    state.progression.shopOpen = false;
+    state.progression.emergency = null;
+    state.combat.inCombat = false;
+    state.combat.enemy = null;
+    state.progression.enemiesRemaining = 0;
+  }
+}
+
 function normalizeStateShape(state) {
   const perk = getCharacterPerk(state);
 
@@ -526,12 +612,7 @@ function normalizeStateShape(state) {
     state.shield.durability = 0;
   }
 
-  if (state.progression.awaitingChoice && state.progression.currentChoiceOptions.length === 0) {
-    const currentLevel = getCurrentLevelData(state);
-    if (currentLevel) {
-      state.progression.currentChoiceOptions = pickChoiceOptions(currentLevel, createRng(state.rngSeed));
-    }
-  }
+  repairProgressionState(state);
 
   clampHealth(state);
 }
@@ -1414,8 +1495,10 @@ export function createCombatEngine({ difficulty = "EASY", seed, character = "leo
       events.push("A shop terminal is available before you move on.");
     }
 
-    if (choiceOptions.length > 0 && state.progression.shopOpen) {
-      events.push("You can shop before committing to the next route.");
+    if (choiceOptions.length > 0) {
+      if (state.progression.shopOpen) {
+        events.push("You can shop before committing to the next route.");
+      }
     } else if (!level.next) {
       state.progression.gameWon = true;
       events.push(`${hero} completed this branch of the mission.`);
@@ -1438,6 +1521,7 @@ export function createCombatEngine({ difficulty = "EASY", seed, character = "leo
     state.progression.awaitingChoice = false;
     state.progression.shopOpen = false;
     state.progression.emergency = null;
+    state.progression.gameWon = false;
     state.progression.currentChoiceOptions = [];
     state.progression.encounterOrder = createEncounterOrder(level, rng);
     state.progression.currentEncounterIndex = 0;

--- a/static/js/gameUI.js
+++ b/static/js/gameUI.js
@@ -227,6 +227,32 @@ function renderShopBox(engine, locked, onBuy, onSell, onContinue) {
   continueBtn.onclick = onContinue;
 }
 
+function canContinueToNextLevel(engine) {
+  return (
+    !isGameOver(engine) &&
+    engine.state.progression.levelComplete &&
+    !engine.state.progression.gameWon &&
+    !engine.hasEmergency() &&
+    !engine.isShopOpen() &&
+    !engine.hasChoices()
+  );
+}
+
+function renderContinueBox(engine, locked, onContinue) {
+  const continueBox = $("#continue-box");
+  const continueBtn = $("#continue-level-btn");
+  if (!continueBox || !continueBtn) return;
+
+  if (!canContinueToNextLevel(engine)) {
+    continueBox.style.display = "none";
+    return;
+  }
+
+  continueBox.style.display = "block";
+  continueBtn.disabled = locked;
+  continueBtn.onclick = onContinue;
+}
+
 function buildSavePayload(engine) {
   const state = engine.state;
 
@@ -269,7 +295,20 @@ async function saveGameToBackend(engine) {
     body: JSON.stringify(payload)
   });
 
-  return response.json();
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.includes("application/json")) {
+    return {
+      ok: response.ok,
+      message: response.ok ? "Game saved." : "Save failed."
+    };
+  }
+
+  const result = await response.json();
+  if (!response.ok && result.ok !== true) {
+    result.ok = false;
+  }
+
+  return result;
 }
 
 export function bootGameUI({
@@ -450,6 +489,7 @@ export function bootGameUI({
     renderWeaponVisibility(engine);
     renderChoiceBox(engine, handlePathChoice, interactionLocked);
     renderShopBox(engine, interactionLocked, handleShopBuy, handleShopSell, handleShopContinue);
+    renderContinueBox(engine, interactionLocked, handleContinueLevel);
     renderEmergencyBox();
     updateActionAvailability();
   }
@@ -552,6 +592,18 @@ export function bootGameUI({
 
     locked = false;
     await postLevelFlow();
+  }
+
+  async function handleContinueLevel() {
+    if (isInteractionLocked() || !canContinueToNextLevel(engine)) return;
+
+    locked = true;
+    renderAll();
+    const nextLevelEvents = engine.advanceToNextLevel();
+    await runAndRender(nextLevelEvents);
+    await postLevelFlow();
+    locked = false;
+    renderAll();
   }
 
   function registerEmergencyPress() {

--- a/static/js/play.js
+++ b/static/js/play.js
@@ -21,6 +21,8 @@ const difficultyDisplay = document.getElementById("difficulty-display");
 const selectedCharacterDisplay = document.getElementById("selected-character-display");
 
 const loadLatestSaveBtn = document.getElementById("load-latest-save-btn");
+const loadLeonSaveBtn = document.getElementById("load-leon-save-btn");
+const loadQuiteSaveBtn = document.getElementById("load-quite-save-btn");
 const deleteSaveBtn = document.getElementById("delete-save-btn");
 const savePreview = document.getElementById("save-preview");
 
@@ -101,7 +103,7 @@ function showSavePreview(saveData) {
 
 function buildSavedState(saveData) {
   if (saveData.run_state) {
-    return saveData.run_state;
+    return structuredClone(saveData.run_state);
   }
 
   const characterId = (saveData.character_id || "leon").toLowerCase();
@@ -193,8 +195,9 @@ function bootLoadedRun(saveData) {
   window.gameEngine = gameEngine;
 }
 
-async function fetchCurrentSaveData(characterId = selectedCharacter) {
-  const response = await fetch(`/load-game?character_id=${encodeURIComponent(characterId)}`);
+async function fetchCurrentSaveData(characterId = null) {
+  const query = characterId ? `?character_id=${encodeURIComponent(characterId)}` : "";
+  const response = await fetch(`/load-game${query}`);
   const result = await response.json();
 
   if (!result.ok || !result.save_data) {
@@ -255,6 +258,26 @@ async function loadLatestSave() {
   }
 }
 
+async function loadCharacterSave(characterId) {
+  try {
+    const result = await fetchCurrentSaveData(characterId);
+
+    if (!result.ok || !result.saveData) {
+      showNoSavePreview(result.message);
+      return;
+    }
+
+    showSavePreview(result.saveData);
+    bootLoadedRun(result.saveData);
+  } catch (error) {
+    console.error(`Failed to load ${characterId} save data:`, error);
+    setSavePreview([
+      "LOAD FAILED",
+      "Please try again."
+    ]);
+  }
+}
+
 newGameBtn.addEventListener("click", () => {
   showScreen(characterScreen);
 });
@@ -265,7 +288,7 @@ loadGameBtn.addEventListener("click", async () => {
 });
 
 backToMainBtn.addEventListener("click", () => {
-  window.location.href = "/main-menu";
+  window.location.href = backToMainBtn.getAttribute("href") || "/main_menu";
 });
 
 characterBackBtn.addEventListener("click", () => {
@@ -281,7 +304,7 @@ loadBackBtn.addEventListener("click", () => {
 });
 
 gameBackBtn.addEventListener("click", () => {
-  showScreen(startScreen);
+  window.location.href = gameBackBtn.getAttribute("href") || "/main_menu";
 });
 
 characterButtons.forEach((button) => {
@@ -302,6 +325,18 @@ difficultyButtons.forEach((button) => {
 if (loadLatestSaveBtn) {
   loadLatestSaveBtn.addEventListener("click", async () => {
     await loadLatestSave();
+  });
+}
+
+if (loadLeonSaveBtn) {
+  loadLeonSaveBtn.addEventListener("click", async () => {
+    await loadCharacterSave("leon");
+  });
+}
+
+if (loadQuiteSaveBtn) {
+  loadQuiteSaveBtn.addEventListener("click", async () => {
+    await loadCharacterSave("quite");
   });
 }
 

--- a/templates/play.html
+++ b/templates/play.html
@@ -91,6 +91,8 @@
 
         <div class="button-stack">
           <button type="button" id="load-latest-save-btn" class="primary-btn">LOAD LATEST SAVE</button>
+          <button type="button" id="load-leon-save-btn" class="secondary-btn">LOAD LEON SAVE</button>
+          <button type="button" id="load-quite-save-btn" class="secondary-btn">LOAD QUITE SAVE</button>
           <button type="button" id="delete-save-btn" class="danger-btn">DELETE SAVE</button>
         </div>
       </div>
@@ -153,6 +155,13 @@
               <h3>SELL</h3>
               <div id="shop-sell-buttons" class="choice-buttons"></div>
             </div>
+          </div>
+        </div>
+
+        <div id="continue-box" class="path-choice-box" style="display: none;">
+          <h2>NEXT LEVEL READY</h2>
+          <div class="button-stack">
+            <button type="button" id="continue-level-btn" class="primary-btn">CONTINUE TO NEXT LEVEL</button>
           </div>
         </div>
 


### PR DESCRIPTION
## Title
Fix save selection and branch progression recovery

## Summary
This patch fixes the save/load flow for branch runs and resolves the progression issues that were blocking users after Level 5A.

The main problem was that load behavior could fall back to the wrong character save, which made users see stale or unrelated data such as an older Leon save instead of their active Quite run. At the same time, some branch progression states could be saved in an inconsistent form, which caused completed branch levels to look like finished runs or prevented clean continuation into Level 6.

## What Changed
- Fixed save loading so the backend can return the latest valid save for the logged-in user instead of defaulting to Leon when no character is explicitly selected.
- Added character-aware load options in the play screen so Leon and Quite saves can be loaded directly.
- Normalized and repaired save payloads when reading from fallback JSON saves to keep character, level, and progression state aligned.
- Hardened save/load behavior around SQLite failures by continuing to use the local JSON fallback save path when the database is unavailable.
- Cleared stale session state on login/guest login so one user or character selection does not leak into another session.
- Fixed branch progression recovery in the combat engine so branch levels with choices or a following level are not incorrectly marked as fully won.
- Added repair logic for corrupted in-progress saves so older bad states can still resume correctly.
- Added a manual "Continue to Next Level" control as a safe fallback when a completed level should advance to the next stage.
- Added `/main-menu` routing support to match frontend navigation.

## User Impact
- Players can complete 5A and continue into Level 6 correctly.
- Save and reload now preserve the correct user, character, and branch progress.
- The load screen no longer silently pulls the wrong Leon save when the active run belongs to Quite.
- Recovery is better even when the SQLite database on this environment becomes unstable.

## Testing
- Verified branch creation and clean commit for this patch.
- Verified save/load round-trip for a Quite run at `6A`.
- Verified `/load-game` without a character hint returns the newest valid save for the logged-in user.
- Verified character-specific load paths for both Leon and Quite.
- Verified the app still serves the main menu route through both `/main_menu` and `/main-menu`.

## Notes
- SQLite on this environment still shows intermittent disk I/O issues, so the JSON fallback save path remains important for reliability.
- This patch focuses on correctness and recovery for current save data rather than removing older historical save files.
