### PR TITLE
Rework Play Screen Layout and Shop Terminal

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -375,7 +375,7 @@ body::before {
 
 .play-page .screen-wrap {
   width: min(97vw, 1720px);
-  min-height: calc(100vh - 20px);
+  min-height: calc(100vh - 12px);
   margin: auto;
 }
 
@@ -590,9 +590,9 @@ body::before {
 }
 
 .play-page .game-panel {
-  height: calc(100vh - 20px);
+  height: calc(100dvh - 12px);
   min-height: 0;
-  padding: 48px 16px 16px;
+  padding: 12px;
   background:
     linear-gradient(180deg, rgba(6, 8, 12, 0.94), rgba(2, 3, 6, 0.92)),
     rgba(0, 0, 0, 0.88);
@@ -608,12 +608,20 @@ body::before {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 10px;
-  padding: 10px 14px;
+  margin-bottom: 8px;
+  padding: 8px 12px 8px 58px;
   border: var(--panel-border);
   border-radius: 14px;
   background: linear-gradient(180deg, rgba(16, 22, 31, 0.92), rgba(7, 11, 18, 0.96));
-  font-size: 0.72rem;
+  font-size: 0.66rem;
+}
+
+.play-page .game-panel #game-back-btn {
+  top: 20px;
+  left: 24px;
+  width: 38px;
+  height: 38px;
+  border-radius: 9px;
 }
 
 .play-page .top-right {
@@ -627,20 +635,22 @@ body::before {
   display: flex;
   flex-direction: column;
   flex: 1;
-  gap: 12px;
+  gap: 8px;
   min-height: 0;
 }
 
 .play-page .top-game-row {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 20px;
+  flex: 1;
+  gap: 0;
   align-items: stretch;
+  min-height: 0;
 }
 
 .play-page .graphics-area {
   position: relative;
-  height: clamp(320px, calc(100vh - 400px), 620px);
+  height: 100%;
   min-height: 0;
   padding: 0;
   border: var(--panel-border);
@@ -658,7 +668,7 @@ body::before {
   justify-content: space-between;
   min-height: 0;
   height: 100%;
-  padding: 18px;
+  padding: 14px;
   --battle-accent: #9ab5d3;
   --battle-accent-soft: rgba(154, 181, 211, 0.22);
   --battle-edge-glow: rgba(104, 156, 220, 0.3);
@@ -784,14 +794,14 @@ body::before {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   grid-template-areas: "enemy player";
-  gap: 18px;
+  gap: 14px;
   align-items: start;
 }
 
 .play-page .battle-status {
-  padding: 16px 18px;
+  padding: 12px 14px;
   border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 18px;
+  border-radius: 14px;
   background: linear-gradient(180deg, rgba(9, 16, 24, 0.74), rgba(5, 9, 13, 0.92));
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   backdrop-filter: blur(3px);
@@ -818,8 +828,8 @@ body::before {
 .play-page .battle-status-heading {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-bottom: 10px;
+  gap: 3px;
+  margin-bottom: 7px;
 }
 
 .play-page .battle-status-label,
@@ -830,23 +840,23 @@ body::before {
 }
 
 .play-page .battle-status strong {
-  font-size: 1rem;
+  font-size: 0.92rem;
   font-weight: 400;
 }
 
 .play-page .battle-status-meta,
 .play-page .battle-status-submeta {
-  margin: 8px 0 0;
+  margin: 6px 0 0;
   color: #e2e7ec;
-  font-size: 0.66rem;
-  line-height: 1.7;
+  font-size: 0.62rem;
+  line-height: 1.55;
 }
 
 .play-page .battle-bar {
   position: relative;
   width: 100%;
-  height: 12px;
-  margin-top: 6px;
+  height: 9px;
+  margin-top: 5px;
   border-radius: 999px;
   overflow: hidden;
   background: rgba(255, 255, 255, 0.08);
@@ -876,22 +886,22 @@ body::before {
 .play-page .battle-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
 }
 
 .play-page .battle-enemy-tags {
   justify-content: flex-start;
-  margin-top: 10px;
+  margin-top: 8px;
 }
 
 .play-page .battle-enemy-tag,
 .play-page .battle-tag {
-  padding: 5px 10px;
+  padding: 4px 9px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   color: #f7f8fa;
-  font-size: 0.56rem;
+  font-size: 0.52rem;
   letter-spacing: 0.8px;
 }
 
@@ -902,17 +912,18 @@ body::before {
 .play-page .battle-actors {
   flex: 1;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 220px minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) 190px minmax(0, 1fr);
   grid-template-areas: "enemy fx player";
   align-items: end;
-  gap: 14px;
-  min-height: clamp(230px, 31vh, 380px);
-  padding: 12px 12px 0;
+  gap: 10px;
+  min-height: 0;
+  padding: 6px 10px 0;
 }
 
 .play-page .battle-actor {
   position: relative;
-  min-height: clamp(230px, 31vh, 380px);
+  height: 100%;
+  min-height: 0;
   display: flex;
   align-items: end;
   justify-content: center;
@@ -934,18 +945,18 @@ body::before {
 
 .play-page .battle-actor-image {
   max-width: 100%;
-  max-height: clamp(240px, 36vh, 430px);
+  max-height: min(100%, clamp(190px, 27vh, 340px));
   object-fit: contain;
   filter: drop-shadow(0 22px 30px rgba(0, 0, 0, 0.48));
 }
 
 .play-page .battle-player .battle-actor-image {
-  max-height: clamp(300px, 43vh, 470px);
+  max-height: min(100%, clamp(220px, 32vh, 370px));
   transform-origin: right bottom;
 }
 
 .play-page .battle-enemy .battle-actor-image {
-  max-height: clamp(280px, 40vh, 450px);
+  max-height: min(100%, clamp(215px, 31vh, 360px));
   transform-origin: left bottom;
   animation: enemy-idle 3.8s ease-in-out infinite;
 }
@@ -963,7 +974,7 @@ body::before {
 
 .play-page .battle-fx {
   position: relative;
-  min-height: 220px;
+  min-height: 170px;
   pointer-events: none;
 }
 
@@ -979,34 +990,34 @@ body::before {
 .play-page .battle-fx-image-action {
   right: 18%;
   top: 34%;
-  width: clamp(92px, 12vw, 150px);
+  width: clamp(82px, 10vw, 132px);
 }
 
 .play-page .battle-fx-image-impact {
   left: 10%;
   top: 20%;
-  width: clamp(90px, 11vw, 140px);
+  width: clamp(80px, 9vw, 124px);
 }
 
 .play-page .battle-stage-footer {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 7px;
 }
 
 .play-page .battle-caption {
-  padding: 16px 18px 18px;
+  padding: 9px 12px 10px;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 18px;
+  border-radius: 14px;
   background: linear-gradient(180deg, rgba(6, 10, 16, 0.88), rgba(5, 9, 12, 0.96));
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 0 32px var(--battle-edge-glow);
 }
 
 .play-page .story-text {
   max-width: 100%;
-  margin-top: 6px;
-  font-size: 0.92rem;
-  line-height: 1.8;
+  margin-top: 4px;
+  font-size: 0.74rem;
+  line-height: 1.4;
   white-space: pre-line;
   text-shadow: 0 0 14px rgba(0, 0, 0, 0.45);
 }
@@ -1103,8 +1114,8 @@ body::before {
 .play-page .todo-box h2,
 .play-page .stats-actions h3 {
   margin-top: 0;
-  margin-bottom: 12px;
-  font-size: 0.85rem;
+  margin-bottom: 6px;
+  font-size: 0.78rem;
   font-weight: 400;
 }
 
@@ -1119,7 +1130,7 @@ body::before {
   display: flex;
   flex-direction: column;
   flex: 1;
-  gap: 10px;
+  gap: 6px;
   min-height: 0;
   overflow-y: auto;
   padding-right: 8px;
@@ -1127,11 +1138,11 @@ body::before {
 }
 
 .play-page .combat-log-entry {
-  padding: 12px 14px;
+  padding: 7px 10px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.05);
-  font-size: 0.72rem;
-  line-height: 1.5;
+  font-size: 0.62rem;
+  line-height: 1.35;
 }
 
 .play-page .choice-buttons {
@@ -1172,10 +1183,70 @@ body::before {
   flex-wrap: wrap;
 }
 
+.play-page .shop-box {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.play-page .shop-header {
+  flex: 0 0 auto;
+  margin-bottom: 8px;
+}
+
+.play-page .shop-header .secondary-btn {
+  padding: 9px 16px;
+}
+
 .play-page .shop-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 16px;
+  flex: 1;
+  gap: 12px;
+  min-height: 0;
+}
+
+.play-page .shop-grid > div {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.play-page .shop-grid .choice-buttons {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 6px;
+  scrollbar-gutter: stable;
+}
+
+.play-page .shop-box .choice-buttons {
+  gap: 7px;
+}
+
+.play-page .shop-box .choice-btn {
+  gap: 4px;
+  min-height: 0;
+  padding: 8px 10px;
+}
+
+.play-page .shop-box .choice-title {
+  font-size: 0.66rem;
+}
+
+.play-page .shop-box .choice-desc {
+  font-size: 0.58rem;
+}
+
+.play-page .game-main.shop-open .game-bottom {
+  display: none;
+}
+
+.play-page .game-main.shop-open .shop-box {
+  flex: 0 0 clamp(190px, 23vh, 260px);
+  max-height: clamp(190px, 23vh, 260px);
+  padding: 12px;
 }
 
 .play-page .emergency-prompt {
@@ -1193,8 +1264,8 @@ body::before {
 .play-page .game-bottom {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  height: clamp(250px, 25vh, 300px);
-  gap: 12px;
+  height: clamp(174px, 17vh, 190px);
+  gap: 8px;
   align-items: stretch;
 }
 
@@ -1202,9 +1273,9 @@ body::before {
 .play-page .combat-log-box {
   height: 100%;
   min-height: 0;
-  padding: 18px;
+  padding: 12px;
   border: var(--panel-border);
-  border-radius: 18px;
+  border-radius: 14px;
   background: linear-gradient(180deg, rgba(8, 10, 15, 0.92), rgba(3, 4, 8, 0.9));
   overflow: hidden;
 }
@@ -1212,11 +1283,13 @@ body::before {
 .play-page .todo-buttons {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 5px;
 }
 
 .play-page .todo-box .action-btn {
-  padding: 8px 14px;
+  min-height: 22px;
+  padding: 3px 12px;
+  font-size: 0.66rem;
 }
 
 .play-page .stats-actions {
@@ -1241,8 +1314,8 @@ body::before {
   min-height: 0;
   margin: 0;
   padding-left: 18px;
-  font-size: 0.72rem;
-  line-height: 1.9;
+  font-size: 0.66rem;
+  line-height: 1.65;
   max-height: none;
   overflow-y: auto;
   padding-right: 8px;
@@ -1396,9 +1469,19 @@ body::before {
   .play-page .game-panel {
     height: auto;
     min-height: auto;
+    padding-top: 16px;
     padding-inline: 18px;
     padding-bottom: 20px;
     overflow: visible;
+  }
+
+  .play-page .game-panel #game-back-btn {
+    top: 25px;
+    left: 32px;
+  }
+
+  .play-page .game-topbar {
+    padding-left: 66px;
   }
 
   .play-page .top-game-row,
@@ -1467,7 +1550,7 @@ body::before {
 
   .play-page .todo-box,
   .play-page .combat-log-box {
-    height: 240px;
+    height: 220px;
   }
 
   .play-page .shop-grid {

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -374,8 +374,11 @@ body::before {
 }
 
 .play-page .screen-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: min(97vw, 1720px);
-  min-height: calc(100vh - 12px);
+  min-height: calc(100dvh - 12px);
   margin: auto;
 }
 
@@ -390,8 +393,11 @@ body::before {
 }
 
 .play-page .panel:not(.game-panel) {
+  width: min(90vw, 900px);
   max-width: 900px;
+  max-height: calc(100dvh - 48px);
   margin: 0 auto;
+  overflow-y: auto;
 }
 
 .play-page .panel.active {
@@ -590,6 +596,7 @@ body::before {
 }
 
 .play-page .game-panel {
+  width: 100%;
   height: calc(100dvh - 12px);
   min-height: 0;
   padding: 12px;
@@ -1191,18 +1198,18 @@ body::before {
 
 .play-page .shop-header {
   flex: 0 0 auto;
-  margin-bottom: 8px;
+  margin-bottom: 18px;
 }
 
 .play-page .shop-header .secondary-btn {
-  padding: 9px 16px;
+  padding: 12px 22px;
 }
 
 .play-page .shop-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   flex: 1;
-  gap: 12px;
+  gap: 18px;
   min-height: 0;
 }
 
@@ -1217,26 +1224,31 @@ body::before {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding-right: 6px;
+  padding-right: 10px;
   scrollbar-gutter: stable;
 }
 
 .play-page .shop-box .choice-buttons {
-  gap: 7px;
+  gap: 12px;
 }
 
 .play-page .shop-box .choice-btn {
-  gap: 4px;
+  gap: 8px;
   min-height: 0;
-  padding: 8px 10px;
+  padding: 18px 20px;
 }
 
 .play-page .shop-box .choice-title {
-  font-size: 0.66rem;
+  font-size: 0.82rem;
 }
 
 .play-page .shop-box .choice-desc {
-  font-size: 0.58rem;
+  font-size: 0.68rem;
+  line-height: 1.55;
+}
+
+.play-page .game-main.shop-open .top-game-row {
+  display: none;
 }
 
 .play-page .game-main.shop-open .game-bottom {
@@ -1244,9 +1256,9 @@ body::before {
 }
 
 .play-page .game-main.shop-open .shop-box {
-  flex: 0 0 clamp(190px, 23vh, 260px);
-  max-height: clamp(190px, 23vh, 260px);
-  padding: 12px;
+  flex: 1 1 auto;
+  max-height: none;
+  padding: 26px 28px;
 }
 
 .play-page .emergency-prompt {

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -590,11 +590,13 @@ body::before {
 }
 
 .play-page .game-panel {
-  min-height: calc(100vh - 20px);
-  padding: 70px 24px 24px;
+  height: calc(100vh - 20px);
+  min-height: 0;
+  padding: 48px 16px 16px;
   background:
     linear-gradient(180deg, rgba(6, 8, 12, 0.94), rgba(2, 3, 6, 0.92)),
     rgba(0, 0, 0, 0.88);
+  overflow: hidden;
 }
 
 .play-page .game-panel.active {
@@ -606,8 +608,8 @@ body::before {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
-  padding: 16px 18px;
+  margin-bottom: 10px;
+  padding: 10px 14px;
   border: var(--panel-border);
   border-radius: 14px;
   background: linear-gradient(180deg, rgba(16, 22, 31, 0.92), rgba(7, 11, 18, 0.96));
@@ -625,7 +627,7 @@ body::before {
   display: flex;
   flex-direction: column;
   flex: 1;
-  gap: 20px;
+  gap: 12px;
   min-height: 0;
 }
 
@@ -638,7 +640,8 @@ body::before {
 
 .play-page .graphics-area {
   position: relative;
-  min-height: clamp(620px, 72vh, 920px);
+  height: clamp(320px, calc(100vh - 400px), 620px);
+  min-height: 0;
   padding: 0;
   border: var(--panel-border);
   border-radius: 18px;
@@ -653,9 +656,9 @@ body::before {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  min-height: clamp(620px, 72vh, 920px);
+  min-height: 0;
   height: 100%;
-  padding: 22px;
+  padding: 18px;
   --battle-accent: #9ab5d3;
   --battle-accent-soft: rgba(154, 181, 211, 0.22);
   --battle-edge-glow: rgba(104, 156, 220, 0.3);
@@ -903,13 +906,13 @@ body::before {
   grid-template-areas: "enemy fx player";
   align-items: end;
   gap: 14px;
-  min-height: clamp(360px, 46vh, 560px);
-  padding: 18px 12px 0;
+  min-height: clamp(230px, 31vh, 380px);
+  padding: 12px 12px 0;
 }
 
 .play-page .battle-actor {
   position: relative;
-  min-height: clamp(360px, 46vh, 560px);
+  min-height: clamp(230px, 31vh, 380px);
   display: flex;
   align-items: end;
   justify-content: center;
@@ -931,18 +934,18 @@ body::before {
 
 .play-page .battle-actor-image {
   max-width: 100%;
-  max-height: clamp(300px, 44vh, 560px);
+  max-height: clamp(240px, 36vh, 430px);
   object-fit: contain;
   filter: drop-shadow(0 22px 30px rgba(0, 0, 0, 0.48));
 }
 
 .play-page .battle-player .battle-actor-image {
-  max-height: clamp(460px, 66vh, 700px);
+  max-height: clamp(300px, 43vh, 470px);
   transform-origin: right bottom;
 }
 
 .play-page .battle-enemy .battle-actor-image {
-  max-height: clamp(430px, 62vh, 700px);
+  max-height: clamp(280px, 40vh, 450px);
   transform-origin: left bottom;
   animation: enemy-idle 3.8s ease-in-out infinite;
 }
@@ -1092,7 +1095,7 @@ body::before {
 .play-page .combat-log-box {
   display: flex;
   flex-direction: column;
-  min-height: clamp(280px, 30vh, 380px);
+  min-height: 0;
 }
 
 .play-page .combat-log-box h2,
@@ -1119,6 +1122,7 @@ body::before {
   gap: 10px;
   min-height: 0;
   overflow-y: auto;
+  padding-right: 8px;
   scrollbar-gutter: stable;
 }
 
@@ -1188,27 +1192,35 @@ body::before {
 
 .play-page .game-bottom {
   display: grid;
-  grid-template-columns: minmax(340px, 0.92fr) minmax(0, 1.08fr);
-  gap: 20px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  height: clamp(250px, 25vh, 300px);
+  gap: 12px;
   align-items: stretch;
 }
 
 .play-page .todo-box,
 .play-page .combat-log-box {
-  min-height: clamp(280px, 30vh, 380px);
-  padding: 20px;
+  height: 100%;
+  min-height: 0;
+  padding: 18px;
   border: var(--panel-border);
   border-radius: 18px;
   background: linear-gradient(180deg, rgba(8, 10, 15, 0.92), rgba(3, 4, 8, 0.9));
+  overflow: hidden;
 }
 
 .play-page .todo-buttons {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
+}
+
+.play-page .todo-box .action-btn {
+  padding: 8px 14px;
 }
 
 .play-page .stats-actions {
+  flex: 1;
   min-height: 0;
 }
 
@@ -1225,11 +1237,13 @@ body::before {
 }
 
 .play-page .stats-actions ul {
+  flex: 1;
+  min-height: 0;
   margin: 0;
   padding-left: 18px;
   font-size: 0.72rem;
   line-height: 1.9;
-  max-height: clamp(180px, 22vh, 280px);
+  max-height: none;
   overflow-y: auto;
   padding-right: 8px;
 }
@@ -1380,9 +1394,11 @@ body::before {
   }
 
   .play-page .game-panel {
+    height: auto;
     min-height: auto;
     padding-inline: 18px;
     padding-bottom: 20px;
+    overflow: visible;
   }
 
   .play-page .top-game-row,
@@ -1392,7 +1408,8 @@ body::before {
 
   .play-page .graphics-area,
   .play-page .battle-stage {
-    min-height: 370px;
+    height: auto;
+    min-height: 360px;
   }
 
   .play-page .battle-hud {
@@ -1445,11 +1462,12 @@ body::before {
 
   .play-page .game-bottom {
     grid-template-columns: 1fr;
+    height: auto;
   }
 
   .play-page .todo-box,
   .play-page .combat-log-box {
-    min-height: 240px;
+    height: 240px;
   }
 
   .play-page .shop-grid {
@@ -1458,7 +1476,7 @@ body::before {
 
   .play-page .graphics-area,
   .play-page .battle-stage {
-    min-height: 340px;
+    min-height: 320px;
   }
 
   .play-page .battle-stage {

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -539,6 +539,11 @@ body::before {
   object-fit: contain;
 }
 
+.play-page .character-card[data-character="quite"] img {
+  object-fit: cover;
+  object-position: center;
+}
+
 .play-page .character-name {
   color: var(--text-primary);
   font-size: 0.9rem;
@@ -1203,6 +1208,23 @@ body::before {
 
 .play-page .shop-header .secondary-btn {
   padding: 12px 22px;
+}
+
+.play-page .shop-dialogue {
+  flex: 0 0 auto;
+  max-height: clamp(78px, 12vh, 120px);
+  margin-bottom: 18px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(6, 10, 16, 0.88), rgba(5, 9, 12, 0.96));
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
+.play-page .shop-dialogue .story-text {
+  font-size: 0.78rem;
+  line-height: 1.45;
 }
 
 .play-page .shop-grid {

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -631,7 +631,7 @@ body::before {
 
 .play-page .top-game-row {
   display: grid;
-  grid-template-columns: minmax(0, 1.72fr) minmax(360px, 0.82fr);
+  grid-template-columns: 1fr;
   gap: 20px;
   align-items: stretch;
 }
@@ -1092,13 +1092,13 @@ body::before {
 .play-page .combat-log-box {
   display: flex;
   flex-direction: column;
-  min-height: clamp(620px, 72vh, 920px);
+  min-height: clamp(280px, 30vh, 380px);
 }
 
 .play-page .combat-log-box h2,
 .play-page .path-choice-box h2,
 .play-page .todo-box h2,
-.play-page .player-stat-box h2 {
+.play-page .stats-actions h3 {
   margin-top: 0;
   margin-bottom: 12px;
   font-size: 0.85rem;
@@ -1188,13 +1188,14 @@ body::before {
 
 .play-page .game-bottom {
   display: grid;
-  grid-template-columns: minmax(360px, 0.95fr) minmax(0, 1.05fr);
+  grid-template-columns: minmax(340px, 0.92fr) minmax(0, 1.08fr);
   gap: 20px;
+  align-items: stretch;
 }
 
 .play-page .todo-box,
-.play-page .player-stat-box {
-  min-height: 0;
+.play-page .combat-log-box {
+  min-height: clamp(280px, 30vh, 380px);
   padding: 20px;
   border: var(--panel-border);
   border-radius: 18px;
@@ -1205,6 +1206,10 @@ body::before {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.play-page .stats-actions {
+  min-height: 0;
 }
 
 .play-page .action-btn {
@@ -1219,12 +1224,12 @@ body::before {
   pointer-events: none;
 }
 
-.play-page .player-stat-box ul {
+.play-page .stats-actions ul {
   margin: 0;
   padding-left: 18px;
   font-size: 0.72rem;
   line-height: 1.9;
-  max-height: 280px;
+  max-height: clamp(180px, 22vh, 280px);
   overflow-y: auto;
   padding-right: 8px;
 }
@@ -1386,8 +1391,7 @@ body::before {
   }
 
   .play-page .graphics-area,
-  .play-page .battle-stage,
-  .play-page .combat-log-box {
+  .play-page .battle-stage {
     min-height: 370px;
   }
 
@@ -1441,6 +1445,11 @@ body::before {
 
   .play-page .game-bottom {
     grid-template-columns: 1fr;
+  }
+
+  .play-page .todo-box,
+  .play-page .combat-log-box {
+    min-height: 240px;
   }
 
   .play-page .shop-grid {

--- a/static/js/gameUI.js
+++ b/static/js/gameUI.js
@@ -230,13 +230,18 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function typeWriter(element, text, speed = 24, isStale = () => false) {
-  if (!element) return;
+async function typeWriter(target, text, speed = 24, isStale = () => false) {
+  const elements = (Array.isArray(target) ? target : [target]).filter(Boolean);
+  if (elements.length === 0) return;
 
-  element.textContent = "";
+  elements.forEach((element) => {
+    element.textContent = "";
+  });
   for (let i = 0; i < text.length; i += 1) {
     if (isStale()) return;
-    element.textContent += text[i];
+    elements.forEach((element) => {
+      element.textContent += text[i];
+    });
     await sleep(speed);
   }
 }
@@ -926,6 +931,7 @@ export function bootGameUI({
   });
 
   const storyText = $("#story-text");
+  const shopStoryText = $("#shop-story-text");
   const emergencyBox = $("#emergency-box");
   const emergencyTitle = $("#emergency-title");
   const emergencyPrompt = $("#emergency-prompt");
@@ -1027,6 +1033,16 @@ export function bootGameUI({
 
   function isInteractionLocked() {
     return locked || isAnimatingEvents;
+  }
+
+  function setStoryText(text) {
+    if (storyText) {
+      storyText.textContent = text;
+    }
+
+    if (shopStoryText) {
+      shopStoryText.textContent = text;
+    }
   }
 
   function areMainActionsLocked() {
@@ -1182,7 +1198,7 @@ export function bootGameUI({
     const renderId = ++storyRenderId;
     isAnimatingEvents = true;
     renderAll();
-    await playEventSequence(storyText, events, 24, 460, () => renderId !== storyRenderId);
+    await playEventSequence([storyText, shopStoryText], events, 24, 460, () => renderId !== storyRenderId);
 
     if (renderId !== storyRenderId) {
       return;
@@ -1369,16 +1385,12 @@ export function bootGameUI({
         }
 
         appendCombatLog(message);
-        if (storyText) {
-          storyText.textContent = message;
-        }
+        setStoryText(message);
       } catch (error) {
         console.error("Save failed:", error);
         playErrorBeep();
         appendCombatLog("Save failed.");
-        if (storyText) {
-          storyText.textContent = "Save failed.";
-        }
+        setStoryText("Save failed.");
       }
     });
   }

--- a/static/js/gameUI.js
+++ b/static/js/gameUI.js
@@ -776,7 +776,10 @@ function renderShopBox(engine, locked, onBuy, onSell, onContinue) {
   const continueBtn = $("#shop-continue-btn");
   if (!shopBox || !buyButtons || !sellButtons || !continueBtn) return;
 
+  const gameMain = shopBox.closest(".game-main");
+
   if (!engine.isShopOpen() || isGameOver(engine)) {
+    gameMain?.classList.remove("shop-open");
     shopBox.style.display = "none";
     buyButtons.innerHTML = "";
     sellButtons.innerHTML = "";
@@ -784,7 +787,8 @@ function renderShopBox(engine, locked, onBuy, onSell, onContinue) {
   }
 
   const coins = engine.state.inventory.coins;
-  shopBox.style.display = "block";
+  gameMain?.classList.add("shop-open");
+  shopBox.style.display = "flex";
   buyButtons.innerHTML = "";
   sellButtons.innerHTML = "";
 
@@ -1025,6 +1029,16 @@ export function bootGameUI({
     return locked || isAnimatingEvents;
   }
 
+  function areMainActionsLocked() {
+    return (
+      isGameOver(engine) ||
+      isInteractionLocked() ||
+      engine.hasEmergency() ||
+      engine.isShopOpen() ||
+      engine.hasChoices()
+    );
+  }
+
   function updateActionAvailability() {
     const dead = isGameOver(engine);
     const inCombat = engine.state.combat.inCombat;
@@ -1039,6 +1053,7 @@ export function bootGameUI({
       ["defend-btn", dead || lockedOut || !inCombat],
       ["inventory-btn", dead || lockedOut],
       ["save-btn", interactionLocked || emergencyActive],
+      ["stats-btn", lockedOut],
       ["pistol-btn", dead || interactionLocked || !inCombat],
       ["rifle-btn", dead || interactionLocked || !inCombat || !engine.state.rifle.owned],
       ["knife-btn", dead || interactionLocked || !inCombat],
@@ -1318,7 +1333,7 @@ export function bootGameUI({
 
   if (attackBtn) {
     attackBtn.addEventListener("click", () => {
-      if (isInteractionLocked() || isGameOver(engine) || engine.hasEmergency() || engine.isShopOpen() || engine.hasChoices()) return;
+      if (areMainActionsLocked()) return;
       showAttackActions();
       renderAll();
     });
@@ -1332,7 +1347,7 @@ export function bootGameUI({
 
   if (inventoryBtn) {
     inventoryBtn.addEventListener("click", () => {
-      if (isInteractionLocked() || isGameOver(engine) || engine.hasEmergency() || engine.isShopOpen() || engine.hasChoices()) return;
+      if (areMainActionsLocked()) return;
       showInventoryActions();
       renderAll();
     });
@@ -1370,6 +1385,7 @@ export function bootGameUI({
 
   if (statsBtn) {
     statsBtn.addEventListener("click", () => {
+      if (areMainActionsLocked()) return;
       showStatsActions();
       renderAll();
     });

--- a/static/js/gameUI.js
+++ b/static/js/gameUI.js
@@ -271,8 +271,10 @@ function isGameOver(engine) {
   return engine.state.progression.gameOver || engine.state.inventory.health <= 0;
 }
 
+const ACTION_GROUP_IDS = ["main-actions", "attack-actions", "inventory-actions", "stats-actions"];
+
 function showActionGroup(groupId) {
-  ["main-actions", "attack-actions", "inventory-actions"].forEach((id) => {
+  ACTION_GROUP_IDS.forEach((id) => {
     const element = document.getElementById(id);
     if (element) {
       element.style.display = id === groupId ? "flex" : "none";
@@ -290,6 +292,10 @@ function showAttackActions() {
 
 function showInventoryActions() {
   showActionGroup("inventory-actions");
+}
+
+function showStatsActions() {
+  showActionGroup("stats-actions");
 }
 
 function formatPercent(value) {
@@ -1297,6 +1303,7 @@ export function bootGameUI({
   const defendBtn = $("#defend-btn");
   const inventoryBtn = $("#inventory-btn");
   const saveBtn = $("#save-btn");
+  const statsBtn = $("#stats-btn");
   const pistolBtn = $("#pistol-btn");
   const rifleBtn = $("#rifle-btn");
   const knifeBtn = $("#knife-btn");
@@ -1307,6 +1314,7 @@ export function bootGameUI({
   const medkitBtn = $("#medkit-btn");
   const shieldBtn = $("#shield-btn");
   const inventoryBackBtn = $("#inventory-back-btn");
+  const statsBackBtn = $("#stats-back-btn");
 
   if (attackBtn) {
     attackBtn.addEventListener("click", () => {
@@ -1360,6 +1368,13 @@ export function bootGameUI({
     });
   }
 
+  if (statsBtn) {
+    statsBtn.addEventListener("click", () => {
+      showStatsActions();
+      renderAll();
+    });
+  }
+
   if (pistolBtn) pistolBtn.addEventListener("click", async () => handleAction("pistol"));
   if (rifleBtn) rifleBtn.addEventListener("click", async () => handleAction("rifle"));
   if (knifeBtn) knifeBtn.addEventListener("click", async () => handleAction("knife"));
@@ -1381,6 +1396,13 @@ export function bootGameUI({
   if (inventoryBackBtn) {
     inventoryBackBtn.addEventListener("click", () => {
       if (isInteractionLocked() || engine.hasEmergency()) return;
+      showMainActions();
+      renderAll();
+    });
+  }
+
+  if (statsBackBtn) {
+    statsBackBtn.addEventListener("click", () => {
       showMainActions();
       renderAll();
     });

--- a/templates/play.html
+++ b/templates/play.html
@@ -208,10 +208,6 @@
             </div>
           </div>
 
-          <div class="combat-log-box">
-            <h2>COMBAT LOG</h2>
-            <div id="combat-log-list" class="combat-log-list"></div>
-          </div>
         </div>
 
         <div id="emergency-box" class="path-choice-box emergency-box" style="display: none;">
@@ -266,6 +262,7 @@
               <button type="button" class="action-btn" id="defend-btn">DEFEND</button>
               <button type="button" class="action-btn" id="inventory-btn">INVENTORY</button>
               <button type="button" class="action-btn" id="save-btn">SAVE GAME</button>
+              <button type="button" class="action-btn" id="stats-btn">PLAYER STATS</button>
             </div>
 
             <div class="todo-buttons" id="attack-actions" style="display: none;">
@@ -283,26 +280,32 @@
               <button type="button" class="action-btn" id="shield-btn">TOGGLE SHIELD</button>
               <button type="button" class="action-btn" id="inventory-back-btn">BACK</button>
             </div>
+
+            <div class="todo-buttons stats-actions" id="stats-actions" style="display: none;">
+              <h3>PLAYER STATS</h3>
+              <ul id="player-stats-list">
+                <li>CHARACTER: LEON</li>
+                <li>PERK: TACTICAL SPECIALIST</li>
+                <li>HP: 100</li>
+                <li>COINS: 0</li>
+                <li>MED: 2</li>
+                <li>GREN: 2</li>
+                <li>PISTOL: 8/8</li>
+                <li>PISTOL BAG: 16</li>
+                <li>SHIELD: ON (100)</li>
+                <li>AGI / COUR: 20 / 50</li>
+                <li>LEVEL: 1</li>
+                <li>ENEMIES LEFT: 1</li>
+                <li>ENEMY HP: 39</li>
+                <li>STATUS: ALIVE</li>
+              </ul>
+              <button type="button" class="action-btn" id="stats-back-btn">BACK</button>
+            </div>
           </div>
 
-          <div class="player-stat-box">
-            <h2>PLAYER STATS</h2>
-            <ul id="player-stats-list">
-              <li>CHARACTER: LEON</li>
-              <li>PERK: TACTICAL SPECIALIST</li>
-              <li>HP: 100</li>
-              <li>COINS: 0</li>
-              <li>MED: 2</li>
-              <li>GREN: 2</li>
-              <li>PISTOL: 8/8</li>
-              <li>PISTOL BAG: 16</li>
-              <li>SHIELD: ON (100)</li>
-              <li>AGI / COUR: 20 / 50</li>
-              <li>LEVEL: 1</li>
-              <li>ENEMIES LEFT: 1</li>
-              <li>ENEMY HP: 39</li>
-              <li>STATUS: ALIVE</li>
-            </ul>
+          <div class="combat-log-box">
+            <h2>COMBAT LOG</h2>
+            <div id="combat-log-list" class="combat-log-list"></div>
           </div>
         </div>
       </div>

--- a/templates/play.html
+++ b/templates/play.html
@@ -234,6 +234,10 @@
             <h2>SHOP TERMINAL</h2>
             <button type="button" id="shop-continue-btn" class="secondary-btn">CONTINUE</button>
           </div>
+          <div class="shop-dialogue">
+            <span class="battle-caption-label">MISSION FEED</span>
+            <div id="shop-story-text" class="story-text">Mission starting...</div>
+          </div>
           <div class="shop-grid">
             <div>
               <h3>BUY</h3>

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -57,6 +57,39 @@ async function expectPlayerStats(page, characterLabel) {
   await expect(page.locator("#main-actions")).toBeVisible();
 }
 
+async function expectPlayLayout(page) {
+  await expect(page.locator("#battle-stage")).toBeVisible();
+  await expect(page.locator(".todo-box")).toBeVisible();
+  await expect(page.locator(".combat-log-box")).toBeVisible();
+
+  const panelHeights = await page.evaluate(() => {
+    const actions = document.querySelector(".todo-box")?.getBoundingClientRect();
+    const combatLog = document.querySelector(".combat-log-box")?.getBoundingClientRect();
+    const logList = document.querySelector("#combat-log-list");
+
+    return {
+      actionsHeight: actions?.height ?? 0,
+      combatLogHeight: combatLog?.height ?? 0,
+      combatLogOverflow: logList ? window.getComputedStyle(logList).overflowY : "",
+    };
+  });
+
+  expect(Math.abs(panelHeights.actionsHeight - panelHeights.combatLogHeight)).toBeLessThanOrEqual(2);
+  expect(panelHeights.combatLogOverflow).toBe("auto");
+}
+
+async function expectActionSubmenus(page) {
+  await page.getByRole("button", { name: "ATTACK" }).click();
+  await expect(page.locator("#attack-actions")).toBeVisible();
+  await page.locator("#attack-back-btn").click();
+  await expect(page.locator("#main-actions")).toBeVisible();
+
+  await page.getByRole("button", { name: "INVENTORY" }).click();
+  await expect(page.locator("#inventory-actions")).toBeVisible();
+  await page.locator("#inventory-back-btn").click();
+  await expect(page.locator("#main-actions")).toBeVisible();
+}
+
 test("redirects unauthenticated play access back to login", async ({ page }) => {
   const pageErrors = trackPageErrors(page);
 
@@ -86,7 +119,9 @@ test("guest login can reach main menu, settings, and start a new game", async ({
   await expect(page.locator("#settings-modal")).toBeHidden();
 
   await startNewGame(page, "quite");
+  await expectPlayLayout(page);
   await expectPlayerStats(page, "QUITE");
+  await expectActionSubmenus(page);
   await expect(page.locator("#battle-player-name")).toHaveText("QUITE");
   await expect(page.locator("#battle-tags")).toContainText("LEVEL 1");
   await expect(page.locator("#battle-player-image")).toHaveAttribute("src", /quite_idle\.png/);
@@ -114,6 +149,7 @@ test("registered user can view achievements, save, and load a run", async ({ pag
   await expect(page).toHaveURL(/\/main[-_]menu$/);
 
   await startNewGame(page, "leon");
+  await expectPlayLayout(page);
 
   await page.locator("#save-btn").click();
   await expect(page.locator("#story-text")).toContainText("Game saved successfully.", { timeout: 15_000 });
@@ -130,6 +166,7 @@ test("registered user can view achievements, save, and load a run", async ({ pag
 
   await page.locator("#load-latest-save-btn").click();
   await expect(page.locator("#game-screen")).toHaveClass(/active/, { timeout: 20_000 });
+  await expectPlayLayout(page);
   await expectPlayerStats(page, "LEON");
   await expect(page.locator("#battle-player-name")).toHaveText("LEON");
   await expect(page.locator("#battle-enemy-name")).not.toHaveText("NO CONTACT");

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -53,6 +53,26 @@ async function expectPanelCentered(page, selector) {
   expect(Math.abs(metrics.panelCenterY - metrics.viewportCenterY)).toBeLessThanOrEqual(80);
 }
 
+async function expectCharacterPortraitSizing(page) {
+  const sizing = await page.evaluate(() => {
+    const leonImage = document.querySelector('.character-card[data-character="leon"] img');
+    const quiteImage = document.querySelector('.character-card[data-character="quite"] img');
+    const leonRect = leonImage?.getBoundingClientRect();
+    const quiteRect = quiteImage?.getBoundingClientRect();
+
+    return {
+      leonHeight: leonRect?.height ?? 0,
+      quiteHeight: quiteRect?.height ?? 0,
+      leonObjectFit: leonImage ? window.getComputedStyle(leonImage).objectFit : "",
+      quiteObjectFit: quiteImage ? window.getComputedStyle(quiteImage).objectFit : "",
+    };
+  });
+
+  expect(Math.abs(sizing.leonHeight - sizing.quiteHeight)).toBeLessThanOrEqual(2);
+  expect(sizing.leonObjectFit).toBe("contain");
+  expect(sizing.quiteObjectFit).toBe("cover");
+}
+
 async function startNewGame(page, character = "leon") {
   await page.getByRole("button", { name: "PLAY GAME" }).click();
   await expect(page).toHaveURL(/\/play$/);
@@ -61,6 +81,7 @@ async function startNewGame(page, character = "leon") {
   await page.getByRole("button", { name: "NEW GAME" }).click();
   await expect(page.locator("#character-screen")).toHaveClass(/active/);
   await expectPanelCentered(page, "#character-screen");
+  await expectCharacterPortraitSizing(page);
 
   await page.locator(`.character-card[data-character="${character}"]`).click();
   await expect(page.locator("#difficulty-screen")).toHaveClass(/active/);
@@ -206,6 +227,8 @@ async function expectShopLayout(page) {
   await expect(page.locator(".game-main")).toHaveClass(/shop-open/);
   await expect(page.locator("#battle-stage")).toBeHidden();
   await expect(page.locator(".game-bottom")).toBeHidden();
+  await expect(page.locator("#shop-story-text")).toBeVisible();
+  await expect(page.locator("#shop-story-text")).toContainText("SHOP OPEN", { timeout: 15_000 });
   await expect(page.locator("#shop-continue-btn")).toBeVisible();
   await expect(page.locator("#stats-btn")).toBeDisabled();
 
@@ -213,6 +236,7 @@ async function expectShopLayout(page) {
     const gamePanel = document.querySelector("#game-screen")?.getBoundingClientRect();
     const topbar = document.querySelector(".game-topbar")?.getBoundingClientRect();
     const shop = document.querySelector("#shop-box")?.getBoundingClientRect();
+    const shopDialogue = document.querySelector(".shop-dialogue")?.getBoundingClientRect();
     const buyButtons = document.querySelector("#shop-buy-buttons");
     const sellButtons = document.querySelector("#shop-sell-buttons");
     const topGameRow = document.querySelector(".top-game-row");
@@ -225,6 +249,7 @@ async function expectShopLayout(page) {
       shopTop: shop?.top ?? 0,
       shopBottom: shop?.bottom ?? 0,
       shopHeight: shop?.height ?? 0,
+      shopDialogueHeight: shopDialogue?.height ?? 0,
       topGameRowDisplay: topGameRow ? window.getComputedStyle(topGameRow).display : "",
       bottomDisplay: bottom ? window.getComputedStyle(bottom).display : "",
       buyOverflow: buyButtons ? window.getComputedStyle(buyButtons).overflowY : "",
@@ -241,6 +266,7 @@ async function expectShopLayout(page) {
   expect(shopMetrics.shopTop).toBeGreaterThanOrEqual(shopMetrics.topbarBottom);
   expect(shopMetrics.shopBottom).toBeLessThanOrEqual(shopMetrics.gamePanelBottom + 2);
   expect(shopMetrics.shopHeight).toBeGreaterThanOrEqual(shopMetrics.viewportHeight * 0.65);
+  expect(shopMetrics.shopDialogueHeight).toBeGreaterThanOrEqual(70);
   expect(shopMetrics.firstShopOptionHeight).toBeGreaterThanOrEqual(70);
   expect(shopMetrics.gamePanelBottom).toBeLessThanOrEqual(shopMetrics.viewportHeight + 2);
 }

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -49,6 +49,14 @@ async function startNewGame(page, character = "leon") {
   await expect(page.locator("#battle-stage")).toBeVisible();
 }
 
+async function expectPlayerStats(page, characterLabel) {
+  await page.getByRole("button", { name: "PLAYER STATS" }).click();
+  await expect(page.locator("#stats-actions")).toBeVisible();
+  await expect(page.locator("#player-stats-list")).toContainText(`CHARACTER: ${characterLabel}`);
+  await page.locator("#stats-back-btn").click();
+  await expect(page.locator("#main-actions")).toBeVisible();
+}
+
 test("redirects unauthenticated play access back to login", async ({ page }) => {
   const pageErrors = trackPageErrors(page);
 
@@ -78,7 +86,7 @@ test("guest login can reach main menu, settings, and start a new game", async ({
   await expect(page.locator("#settings-modal")).toBeHidden();
 
   await startNewGame(page, "quite");
-  await expect(page.locator("#player-stats-list")).toContainText("CHARACTER: QUITE");
+  await expectPlayerStats(page, "QUITE");
   await expect(page.locator("#battle-player-name")).toHaveText("QUITE");
   await expect(page.locator("#battle-tags")).toContainText("LEVEL 1");
   await expect(page.locator("#battle-player-image")).toHaveAttribute("src", /quite_idle\.png/);
@@ -122,7 +130,7 @@ test("registered user can view achievements, save, and load a run", async ({ pag
 
   await page.locator("#load-latest-save-btn").click();
   await expect(page.locator("#game-screen")).toHaveClass(/active/, { timeout: 20_000 });
-  await expect(page.locator("#player-stats-list")).toContainText("CHARACTER: LEON");
+  await expectPlayerStats(page, "LEON");
   await expect(page.locator("#battle-player-name")).toHaveText("LEON");
   await expect(page.locator("#battle-enemy-name")).not.toHaveText("NO CONTACT");
   expect(pageErrors).toEqual([]);

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+test.use({ viewport: { width: 1366, height: 768 } });
+
 function uniqueCredentials() {
   const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   return {
@@ -46,6 +48,7 @@ async function startNewGame(page, character = "leon") {
   await page.getByRole("button", { name: "EASY" }).click();
   await expect(page.locator("#game-screen")).toHaveClass(/active/);
   await expect(page.locator("#save-btn")).toBeEnabled({ timeout: 20_000 });
+  await expect(page.locator("#stats-btn")).toBeEnabled({ timeout: 20_000 });
   await expect(page.locator("#battle-stage")).toBeVisible();
 }
 
@@ -66,16 +69,38 @@ async function expectPlayLayout(page) {
     const actions = document.querySelector(".todo-box")?.getBoundingClientRect();
     const combatLog = document.querySelector(".combat-log-box")?.getBoundingClientRect();
     const logList = document.querySelector("#combat-log-list");
+    const gameBack = document.querySelector("#game-back-btn")?.getBoundingClientRect();
+    const topbar = document.querySelector(".game-topbar")?.getBoundingClientRect();
+    const missionFeed = document.querySelector(".battle-caption")?.getBoundingClientRect();
+    const graphics = document.querySelector(".graphics-area")?.getBoundingClientRect();
+    const gamePanel = document.querySelector("#game-screen")?.getBoundingClientRect();
+    const gameBottom = document.querySelector(".game-bottom")?.getBoundingClientRect();
 
     return {
       actionsHeight: actions?.height ?? 0,
       combatLogHeight: combatLog?.height ?? 0,
       combatLogOverflow: logList ? window.getComputedStyle(logList).overflowY : "",
+      backTop: gameBack?.top ?? 0,
+      backBottom: gameBack?.bottom ?? 0,
+      topbarTop: topbar?.top ?? 0,
+      topbarBottom: topbar?.bottom ?? 0,
+      missionFeedBottom: missionFeed?.bottom ?? 0,
+      graphicsBottom: graphics?.bottom ?? 0,
+      gamePanelBottom: gamePanel?.bottom ?? 0,
+      gameBottomTop: gameBottom?.top ?? 0,
+      gameBottomBottom: gameBottom?.bottom ?? 0,
+      viewportHeight: window.innerHeight,
     };
   });
 
   expect(Math.abs(panelHeights.actionsHeight - panelHeights.combatLogHeight)).toBeLessThanOrEqual(2);
   expect(panelHeights.combatLogOverflow).toBe("auto");
+  expect(panelHeights.backTop).toBeGreaterThanOrEqual(panelHeights.topbarTop - 2);
+  expect(panelHeights.backBottom).toBeLessThanOrEqual(panelHeights.topbarBottom + 2);
+  expect(panelHeights.missionFeedBottom).toBeLessThanOrEqual(panelHeights.graphicsBottom + 2);
+  expect(panelHeights.graphicsBottom).toBeLessThanOrEqual(panelHeights.gameBottomTop - 4);
+  expect(panelHeights.gameBottomBottom).toBeLessThanOrEqual(panelHeights.gamePanelBottom + 2);
+  expect(panelHeights.gamePanelBottom).toBeLessThanOrEqual(panelHeights.viewportHeight + 2);
 }
 
 async function expectActionSubmenus(page) {
@@ -88,6 +113,102 @@ async function expectActionSubmenus(page) {
   await expect(page.locator("#inventory-actions")).toBeVisible();
   await page.locator("#inventory-back-btn").click();
   await expect(page.locator("#main-actions")).toBeVisible();
+}
+
+async function saveShopState(page) {
+  await page.evaluate(async () => {
+    if (!window.gameEngine?.state) {
+      throw new Error("Game engine was not available for shop-state setup.");
+    }
+
+    const state = structuredClone(window.gameEngine.state);
+    state.progression.currentLevelId = "2";
+    state.progression.enemiesRemaining = 0;
+    state.progression.encounterOrder = [];
+    state.progression.currentEncounterIndex = 0;
+    state.progression.levelComplete = true;
+    state.progression.awaitingChoice = false;
+    state.progression.shopOpen = true;
+    state.progression.gameWon = false;
+    state.progression.gameOver = false;
+    state.progression.currentChoiceOptions = [];
+    state.combat.inCombat = false;
+    state.combat.enemy = null;
+    state.inventory.health = Math.max(state.inventory.health, 80);
+    state.inventory.coins = Math.max(state.inventory.coins, 20);
+
+    const payload = {
+      difficulty: state.difficulty,
+      character_id: state.player.characterId,
+      health: state.inventory.health,
+      medkits: state.inventory.medKits,
+      grenades: state.inventory.grenades,
+      ammo_in_gun: state.pistol.ammoInGun,
+      ammo_in_bag: state.pistol.ammoInBag,
+      mag_capacity: state.pistol.magCapacity,
+      laser_upgrade: state.pistol.hasLaser,
+      shield_owned: state.shield.hasShield,
+      shield_on: state.shield.equipped,
+      current_level_id: state.progression.currentLevelId,
+      enemies_remaining: state.progression.enemiesRemaining,
+      level_complete: state.progression.levelComplete,
+      awaiting_choice: state.progression.awaitingChoice,
+      game_won: state.progression.gameWon,
+      kills: state.analytics.enemiesKilled,
+      damage_dealt: state.analytics.damageDealt,
+      damage_taken: state.analytics.damageTaken,
+      pistol_shots: state.analytics.pistolShotsFired,
+      grenades_used: state.analytics.grenadesUsed,
+      medkits_used: state.analytics.medKitsUsed,
+      reloads: state.analytics.reloads,
+      knife_uses: state.analytics.knivesUsed,
+      run_state: state,
+    };
+
+    const response = await fetch("/save-game", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const result = await response.json().catch(() => ({}));
+    if (!response.ok || result.ok === false) {
+      throw new Error(result.message || "Failed to save forced shop state.");
+    }
+  });
+}
+
+async function expectShopLayout(page) {
+  await expect(page.locator("#shop-box")).toBeVisible();
+  await expect(page.locator(".game-main")).toHaveClass(/shop-open/);
+  await expect(page.locator(".game-bottom")).toBeHidden();
+  await expect(page.locator("#shop-continue-btn")).toBeVisible();
+  await expect(page.locator("#stats-btn")).toBeDisabled();
+
+  const shopMetrics = await page.evaluate(() => {
+    const gamePanel = document.querySelector("#game-screen")?.getBoundingClientRect();
+    const shop = document.querySelector("#shop-box")?.getBoundingClientRect();
+    const buyButtons = document.querySelector("#shop-buy-buttons");
+    const sellButtons = document.querySelector("#shop-sell-buttons");
+    const bottom = document.querySelector(".game-bottom");
+
+    return {
+      gamePanelBottom: gamePanel?.bottom ?? 0,
+      shopBottom: shop?.bottom ?? 0,
+      bottomDisplay: bottom ? window.getComputedStyle(bottom).display : "",
+      buyOverflow: buyButtons ? window.getComputedStyle(buyButtons).overflowY : "",
+      sellOverflow: sellButtons ? window.getComputedStyle(sellButtons).overflowY : "",
+      viewportHeight: window.innerHeight,
+    };
+  });
+
+  expect(shopMetrics.bottomDisplay).toBe("none");
+  expect(shopMetrics.buyOverflow).toBe("auto");
+  expect(shopMetrics.sellOverflow).toBe("auto");
+  expect(shopMetrics.shopBottom).toBeLessThanOrEqual(shopMetrics.gamePanelBottom + 2);
+  expect(shopMetrics.gamePanelBottom).toBeLessThanOrEqual(shopMetrics.viewportHeight + 2);
 }
 
 test("redirects unauthenticated play access back to login", async ({ page }) => {
@@ -170,5 +291,28 @@ test("registered user can view achievements, save, and load a run", async ({ pag
   await expectPlayerStats(page, "LEON");
   await expect(page.locator("#battle-player-name")).toHaveText("LEON");
   await expect(page.locator("#battle-enemy-name")).not.toHaveText("NO CONTACT");
+  expect(pageErrors).toEqual([]);
+});
+
+test("registered user sees compact shop mode with locked stats", async ({ page }) => {
+  const pageErrors = trackPageErrors(page);
+  const credentials = uniqueCredentials();
+
+  await registerAndLogin(page, credentials);
+  const checkpointSave = page.waitForResponse(
+    (response) => response.url().includes("/save-game") && response.request().method() === "POST",
+  );
+  await startNewGame(page, "leon");
+  await checkpointSave;
+  await saveShopState(page);
+
+  await page.goto("/play");
+  await page.getByRole("button", { name: "LOAD GAME" }).click();
+  await expect(page.locator("#load-screen")).toHaveClass(/active/);
+  await expect(page.locator("#save-preview")).toContainText("LEVEL: 2", { timeout: 15_000 });
+
+  await page.locator("#load-latest-save-btn").click();
+  await expect(page.locator("#game-screen")).toHaveClass(/active/, { timeout: 20_000 });
+  await expectShopLayout(page);
   expect(pageErrors).toEqual([]);
 });

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -35,15 +35,36 @@ async function registerAndLogin(page, credentials) {
   await expect(page).toHaveURL(/\/main[-_]menu$/);
 }
 
+async function expectPanelCentered(page, selector) {
+  await expect(page.locator(selector)).toBeVisible();
+
+  const metrics = await page.evaluate((panelSelector) => {
+    const panel = document.querySelector(panelSelector)?.getBoundingClientRect();
+
+    return {
+      panelCenterX: panel ? panel.left + panel.width / 2 : 0,
+      panelCenterY: panel ? panel.top + panel.height / 2 : 0,
+      viewportCenterX: window.innerWidth / 2,
+      viewportCenterY: window.innerHeight / 2,
+    };
+  }, selector);
+
+  expect(Math.abs(metrics.panelCenterX - metrics.viewportCenterX)).toBeLessThanOrEqual(2);
+  expect(Math.abs(metrics.panelCenterY - metrics.viewportCenterY)).toBeLessThanOrEqual(80);
+}
+
 async function startNewGame(page, character = "leon") {
   await page.getByRole("button", { name: "PLAY GAME" }).click();
   await expect(page).toHaveURL(/\/play$/);
+  await expectPanelCentered(page, "#start-screen");
 
   await page.getByRole("button", { name: "NEW GAME" }).click();
   await expect(page.locator("#character-screen")).toHaveClass(/active/);
+  await expectPanelCentered(page, "#character-screen");
 
   await page.locator(`.character-card[data-character="${character}"]`).click();
   await expect(page.locator("#difficulty-screen")).toHaveClass(/active/);
+  await expectPanelCentered(page, "#difficulty-screen");
 
   await page.getByRole("button", { name: "EASY" }).click();
   await expect(page.locator("#game-screen")).toHaveClass(/active/);
@@ -183,31 +204,44 @@ async function saveShopState(page) {
 async function expectShopLayout(page) {
   await expect(page.locator("#shop-box")).toBeVisible();
   await expect(page.locator(".game-main")).toHaveClass(/shop-open/);
+  await expect(page.locator("#battle-stage")).toBeHidden();
   await expect(page.locator(".game-bottom")).toBeHidden();
   await expect(page.locator("#shop-continue-btn")).toBeVisible();
   await expect(page.locator("#stats-btn")).toBeDisabled();
 
   const shopMetrics = await page.evaluate(() => {
     const gamePanel = document.querySelector("#game-screen")?.getBoundingClientRect();
+    const topbar = document.querySelector(".game-topbar")?.getBoundingClientRect();
     const shop = document.querySelector("#shop-box")?.getBoundingClientRect();
     const buyButtons = document.querySelector("#shop-buy-buttons");
     const sellButtons = document.querySelector("#shop-sell-buttons");
+    const topGameRow = document.querySelector(".top-game-row");
     const bottom = document.querySelector(".game-bottom");
+    const firstShopOption = document.querySelector("#shop-buy-buttons .choice-btn")?.getBoundingClientRect();
 
     return {
       gamePanelBottom: gamePanel?.bottom ?? 0,
+      topbarBottom: topbar?.bottom ?? 0,
+      shopTop: shop?.top ?? 0,
       shopBottom: shop?.bottom ?? 0,
+      shopHeight: shop?.height ?? 0,
+      topGameRowDisplay: topGameRow ? window.getComputedStyle(topGameRow).display : "",
       bottomDisplay: bottom ? window.getComputedStyle(bottom).display : "",
       buyOverflow: buyButtons ? window.getComputedStyle(buyButtons).overflowY : "",
       sellOverflow: sellButtons ? window.getComputedStyle(sellButtons).overflowY : "",
+      firstShopOptionHeight: firstShopOption?.height ?? 0,
       viewportHeight: window.innerHeight,
     };
   });
 
+  expect(shopMetrics.topGameRowDisplay).toBe("none");
   expect(shopMetrics.bottomDisplay).toBe("none");
   expect(shopMetrics.buyOverflow).toBe("auto");
   expect(shopMetrics.sellOverflow).toBe("auto");
+  expect(shopMetrics.shopTop).toBeGreaterThanOrEqual(shopMetrics.topbarBottom);
   expect(shopMetrics.shopBottom).toBeLessThanOrEqual(shopMetrics.gamePanelBottom + 2);
+  expect(shopMetrics.shopHeight).toBeGreaterThanOrEqual(shopMetrics.viewportHeight * 0.65);
+  expect(shopMetrics.firstShopOptionHeight).toBeGreaterThanOrEqual(70);
   expect(shopMetrics.gamePanelBottom).toBeLessThanOrEqual(shopMetrics.viewportHeight + 2);
 }
 
@@ -280,9 +314,11 @@ test("registered user can view achievements, save, and load a run", async ({ pag
 
   await page.getByRole("button", { name: "PLAY GAME" }).click();
   await expect(page).toHaveURL(/\/play$/);
+  await expectPanelCentered(page, "#start-screen");
 
   await page.getByRole("button", { name: "LOAD GAME" }).click();
   await expect(page.locator("#load-screen")).toHaveClass(/active/);
+  await expectPanelCentered(page, "#load-screen");
   await expect(page.locator("#save-preview")).toContainText("CHARACTER: LEON", { timeout: 15_000 });
 
   await page.locator("#load-latest-save-btn").click();
@@ -294,7 +330,7 @@ test("registered user can view achievements, save, and load a run", async ({ pag
   expect(pageErrors).toEqual([]);
 });
 
-test("registered user sees compact shop mode with locked stats", async ({ page }) => {
+test("registered user sees expanded shop mode with locked stats", async ({ page }) => {
   const pageErrors = trackPageErrors(page);
   const credentials = uniqueCredentials();
 
@@ -309,6 +345,7 @@ test("registered user sees compact shop mode with locked stats", async ({ page }
   await page.goto("/play");
   await page.getByRole("button", { name: "LOAD GAME" }).click();
   await expect(page.locator("#load-screen")).toHaveClass(/active/);
+  await expectPanelCentered(page, "#load-screen");
   await expect(page.locator("#save-preview")).toContainText("LEVEL: 2", { timeout: 15_000 });
 
   await page.locator("#load-latest-save-btn").click();


### PR DESCRIPTION
This PR improves the play screen layout and interaction flow.

Changes include:

Reworked the play screen to fit better at 100% browser zoom.
Moved the combat log into the lower panel area.
Moved player stats behind a PLAYER STATS action view with a BACK button.
Added internal scrolling for combat log and stats.
Centered the play setup screens, including new game, load game, character select, and difficulty select.
Expanded the shop into a full terminal-style screen.
Restored mission/progression dialogue inside the shop terminal.
Disabled player stats during locked states such as shop, choices, emergencies, and animations.
Adjusted character select portrait sizing so Leon and Quite appear more consistent.
Updated Playwright smoke checks for layout, shop mode, stats toggling, and menu centering.