### PR TITLE
Add client-side and server-side validation checks

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -7,6 +7,7 @@ MIN_USERNAME_LENGTH = 3
 MAX_USERNAME_LENGTH = 80
 MIN_PASSWORD_LENGTH = 6
 MAX_PASSWORD_LENGTH = 255
+MAX_CHAT_MESSAGE_LENGTH = 1000
 USERNAME_PATTERN = re.compile(r"^[a-z0-9_]+$")
 
 
@@ -41,6 +42,24 @@ def validate_auth_password(password, *, field_name="password"):
 
     if len(password) > MAX_PASSWORD_LENGTH:
         return f"{label} must be {MAX_PASSWORD_LENGTH} characters or fewer."
+
+    return None
+
+
+def validate_friend_username(username):
+    return validate_auth_username(username)
+
+
+def normalize_chat_message(message):
+    return str(message or "").strip()
+
+
+def validate_chat_message(message):
+    if message == "":
+        return "Message cannot be empty."
+
+    if len(message) > MAX_CHAT_MESSAGE_LENGTH:
+        return f"Message must be {MAX_CHAT_MESSAGE_LENGTH} characters or fewer."
 
     return None
 
@@ -517,8 +536,20 @@ def load_game():
 def add_friend(user_id):
     current_user = session.get("user_id")
 
-    if not current_user or current_user == user_id:
+    if session.get("is_guest"):
         return redirect(url_for("main_menu"))
+
+    if not current_user:
+        return redirect(url_for("show_login"))
+
+    if current_user == user_id:
+        flash("You cannot add yourself.")
+        return redirect(url_for("main_menu"))
+
+    current_user_record = User.query.get(current_user)
+    if current_user_record is None:
+        session.clear()
+        return redirect(url_for("show_login"))
 
     target_user = User.query.get(user_id)
     if target_user is None:
@@ -549,11 +580,22 @@ def show_friends():
 
     current_user = User.query.get(session.get('user_id'))
     if current_user is None:
+        session.clear()
         return redirect(url_for('show_login'))
     
     if request.method == 'POST':
         from_user_id = session.get('user_id')
-        friend_username = request.form['friend_username'].strip().lower()
+        friend_username = normalize_auth_username(request.form.get('friend_username', ''))
+        friend_username_error = validate_friend_username(friend_username)
+
+        if friend_username_error is not None:
+            flash(friend_username_error)
+            return redirect(url_for('show_friends'))
+
+        if friend_username == current_user.username:
+            flash("You cannot add yourself.")
+            return redirect(url_for('show_friends'))
+
         friend = User.query.filter_by(username=friend_username).first()
 
         if friend:
@@ -632,18 +674,22 @@ def chat(friend_id):
         return redirect(url_for("show_friends"))
 
     if request.method == "POST":
-        msg = request.form.get("message", "").strip()
+        msg = normalize_chat_message(request.form.get("message", ""))
+        message_error = validate_chat_message(msg)
 
-        if msg:
-            message = Message(
-                sender_id=session["user_id"],
-                receiver_id=friend_id,
-                message=msg,
-                timestamp=datetime.utcnow()
-            )
-            db.session.add(message)
-            db.session.commit()
+        if message_error is not None:
+            flash(message_error)
             return redirect(url_for("chat", friend_id=friend_id))
+
+        message = Message(
+            sender_id=session["user_id"],
+            receiver_id=friend_id,
+            message=msg,
+            timestamp=datetime.utcnow()
+        )
+        db.session.add(message)
+        db.session.commit()
+        return redirect(url_for("chat", friend_id=friend_id))
 
     messages = Message.query.filter(
         ((Message.sender_id == current_user) & (Message.receiver_id == friend_id)) |
@@ -709,7 +755,7 @@ def handle_chat_leave(data):
 def handle_chat_send(data):
     current_user = session.get("user_id")
     friend_id = parse_friend_id((data or {}).get("friend_id"))
-    message_text = str((data or {}).get("message", "")).strip()
+    message_text = normalize_chat_message((data or {}).get("message", ""))
 
     if current_user is None or session.get("is_guest"):
         socketio.emit("chat:error", {"message": "Please log in to use chat."}, to=request.sid)
@@ -723,9 +769,10 @@ def handle_chat_send(data):
         socketio.emit("chat:error", {"message": "You can only chat with accepted friends."}, to=request.sid)
         return {"ok": False, "message": "You can only chat with accepted friends."}
 
-    if message_text == "":
-        socketio.emit("chat:error", {"message": "Message cannot be empty."}, to=request.sid)
-        return {"ok": False, "message": "Message cannot be empty."}
+    message_error = validate_chat_message(message_text)
+    if message_error is not None:
+        socketio.emit("chat:error", {"message": message_error}, to=request.sid)
+        return {"ok": False, "message": message_error}
 
     room_key = build_chat_room_key(current_user, friend_id)
     join_room(room_key)

--- a/routes.py
+++ b/routes.py
@@ -1,18 +1,64 @@
+import re
 from app import *
+
+
+
+MIN_USERNAME_LENGTH = 3
+MAX_USERNAME_LENGTH = 80
+MIN_PASSWORD_LENGTH = 6
+MAX_PASSWORD_LENGTH = 255
+USERNAME_PATTERN = re.compile(r"^[a-z0-9_]+$")
+
+
+def normalize_auth_username(username):
+    return str(username or "").strip().lower()
+
+
+def validate_auth_username(username):
+    if username == "":
+        return "Please enter a username."
+
+    if len(username) < MIN_USERNAME_LENGTH:
+        return f"Username must be at least {MIN_USERNAME_LENGTH} characters."
+
+    if len(username) > MAX_USERNAME_LENGTH:
+        return f"Username must be {MAX_USERNAME_LENGTH} characters or fewer."
+
+    if not USERNAME_PATTERN.fullmatch(username):
+        return "Username can only use lowercase letters, numbers, and underscores."
+
+    return None
+
+
+def validate_auth_password(password, *, field_name="password"):
+    label = field_name.capitalize()
+
+    if password == "":
+        return f"Please enter a {field_name}."
+
+    if len(password) < MIN_PASSWORD_LENGTH:
+        return f"{label} must be at least {MIN_PASSWORD_LENGTH} characters."
+
+    if len(password) > MAX_PASSWORD_LENGTH:
+        return f"{label} must be {MAX_PASSWORD_LENGTH} characters or fewer."
+
+    return None
 
 
 @app.route("/")
 @app.route("/login", methods=["GET", "POST"])
 def show_login():
     if request.method == "POST":
-        username = request.form.get("username", "").strip().lower()
-        password = request.form.get("password", "")
+        username = normalize_auth_username(request.form.get("username", ""))
+        password = str(request.form.get("password", ""))
 
-        if username == "":
-            return render_template("login.html", error="Please enter your username.")
+        username_error = validate_auth_username(username)
+        if username_error is not None:
+            return render_template("login.html", error=username_error)
 
-        if password == "":
-            return render_template("login.html", error="Please enter your password.")
+        password_error = validate_auth_password(password)
+        if password_error is not None:
+            return render_template("login.html", error=password_error)
 
         user = User.query.filter_by(username=username).first()
 
@@ -36,15 +82,21 @@ def show_login():
 @app.route("/register", methods=["GET", "POST"])
 def show_register():
     if request.method == "POST":
-        username = request.form.get("username", "").strip().lower()
-        password = request.form.get("password", "")
-        confirm = request.form.get("confirm-password", "")
+        username = normalize_auth_username(request.form.get("username", ""))
+        password = str(request.form.get("password", ""))
+        confirm = str(request.form.get("confirm-password", ""))
 
-        if username == "":
-            return render_template("register.html", error="Please enter a username.")
+        username_error = validate_auth_username(username)
+        if username_error is not None:
+            return render_template("register.html", error=username_error)
 
-        if password == "":
-            return render_template("register.html", error="Please enter a password.")
+        password_error = validate_auth_password(password)
+        if password_error is not None:
+            return render_template("register.html", error=password_error)
+
+        confirm_error = validate_auth_password(confirm, field_name="confirm password")
+        if confirm_error is not None:
+            return render_template("register.html", error=confirm_error)
 
         if password != confirm:
             return render_template("register.html", error="Passwords do not match.")

--- a/routes.py
+++ b/routes.py
@@ -634,7 +634,7 @@ def add_friend(user_id):
 
     if current_user == user_id:
         flash("You cannot add yourself.")
-        return redirect(url_for("main_menu"))
+        return redirect(url_for("show_friends"))
 
     current_user_record = User.query.get(current_user)
     if current_user_record is None:
@@ -644,7 +644,7 @@ def add_friend(user_id):
     target_user = User.query.get(user_id)
     if target_user is None:
         flash("User not found.")
-        return redirect(url_for("main_menu"))
+        return redirect(url_for("show_friends"))
 
     try:
         _, message = create_friend_request(current_user, user_id)

--- a/routes.py
+++ b/routes.py
@@ -64,6 +64,95 @@ def validate_chat_message(message):
     return None
 
 
+def coerce_bounded_int(value, default=0, minimum=0, maximum=None):
+    number = coerce_int(value, default)
+
+    if number < minimum:
+        return minimum
+
+    if maximum is not None and number > maximum:
+        return maximum
+
+    return number
+
+
+def normalize_save_token(value, default, *, max_length=20, transform="preserve"):
+    token = str(value if value is not None else default).strip()
+
+    if transform == "lower":
+        token = token.lower()
+    elif transform == "upper":
+        token = token.upper()
+
+    if not token:
+        return default
+
+    if len(token) > max_length:
+        return default
+
+    if not USERNAME_PATTERN.fullmatch(token.replace("-", "_")):
+        return default
+
+    return token
+
+
+def sanitize_save_request_payload(data):
+    if not isinstance(data, dict) or not data:
+        return None
+
+    difficulty = normalize_save_token(
+        data.get("difficulty"),
+        "EASY",
+        max_length=20,
+        transform="upper"
+    )
+
+    if difficulty not in {"EASY", "NORMAL", "HARD"}:
+        difficulty = "EASY"
+
+    run_state = data.get("run_state")
+    if run_state is not None and not isinstance(run_state, dict):
+        run_state = None
+
+    return {
+        "difficulty": difficulty,
+        "character_id": normalize_save_token(
+            data.get("character_id"),
+            "leon",
+            max_length=20,
+            transform="lower"
+        ),
+        "health": coerce_bounded_int(data.get("health"), 100, minimum=0, maximum=100),
+        "medkits": coerce_bounded_int(data.get("medkits"), 0, minimum=0, maximum=99),
+        "grenades": coerce_bounded_int(data.get("grenades"), 0, minimum=0, maximum=99),
+        "ammo_in_gun": coerce_bounded_int(data.get("ammo_in_gun"), 0, minimum=0, maximum=999),
+        "ammo_in_bag": coerce_bounded_int(data.get("ammo_in_bag"), 0, minimum=0, maximum=999),
+        "mag_capacity": coerce_bounded_int(data.get("mag_capacity"), 8, minimum=0, maximum=999),
+        "laser_upgrade": coerce_bool(data.get("laser_upgrade"), False),
+        "shield_owned": coerce_bool(data.get("shield_owned"), False),
+        "shield_on": coerce_bool(data.get("shield_on"), False),
+        "current_level_id": normalize_save_token(
+            data.get("current_level_id"),
+            "1",
+            max_length=20,
+            transform="preserve"
+        ),
+        "enemies_remaining": coerce_bounded_int(data.get("enemies_remaining"), 0, minimum=0, maximum=999),
+        "level_complete": coerce_bool(data.get("level_complete"), False),
+        "awaiting_choice": coerce_bool(data.get("awaiting_choice"), False),
+        "game_won": coerce_bool(data.get("game_won"), False),
+        "kills": coerce_bounded_int(data.get("kills"), 0, minimum=0, maximum=100000),
+        "damage_dealt": coerce_bounded_int(data.get("damage_dealt"), 0, minimum=0, maximum=1000000),
+        "damage_taken": coerce_bounded_int(data.get("damage_taken"), 0, minimum=0, maximum=1000000),
+        "pistol_shots": coerce_bounded_int(data.get("pistol_shots"), 0, minimum=0, maximum=100000),
+        "grenades_used": coerce_bounded_int(data.get("grenades_used"), 0, minimum=0, maximum=100000),
+        "medkits_used": coerce_bounded_int(data.get("medkits_used"), 0, minimum=0, maximum=100000),
+        "reloads": coerce_bounded_int(data.get("reloads"), 0, minimum=0, maximum=100000),
+        "knife_uses": coerce_bounded_int(data.get("knife_uses"), 0, minimum=0, maximum=100000),
+        "run_state": run_state,
+    }
+
+
 @app.route("/")
 @app.route("/login", methods=["GET", "POST"])
 def show_login():
@@ -432,21 +521,22 @@ def save_game():
         }), 401
 
     data = request.get_json(silent=True)
+    sanitized_data = sanitize_save_request_payload(data)
 
-    if not data:
+    if sanitized_data is None:
         return jsonify({
             "ok": False,
-            "message": "No save data received."
+            "message": "Invalid save data received."
         }), 400
 
-    character_id = str(data.get("character_id", "leon")).lower()
+    character_id = sanitized_data["character_id"]
     session["selected_character"] = character_id
 
-    fallback_payload = build_save_payload_from_request(data)
+    fallback_payload = build_save_payload_from_request(sanitized_data)
 
     try:
         save_data = get_user_save(character_id=character_id, create=True)
-        update_save_data(save_data, data)
+        update_save_data(save_data, sanitized_data)
         db.session.commit()
     except SQLAlchemyError as error:
         db.session.rollback()

--- a/static/js/friends-page.js
+++ b/static/js/friends-page.js
@@ -2,21 +2,91 @@ const friendForm = document.querySelector("[data-friend-form]");
 const friendUsernameInput = document.querySelector("[data-friend-username]");
 const flashMessages = document.querySelectorAll("[data-flash-message]");
 
+const MIN_USERNAME_LENGTH = 3;
+const MAX_USERNAME_LENGTH = 80;
+const USERNAME_PATTERN = /^[a-z0-9_]+$/;
+
+function clearFieldError(input) {
+  if (!input) {
+    return;
+  }
+
+  input.setCustomValidity("");
+}
+
+function showFieldError(input, message) {
+  if (!input) {
+    return false;
+  }
+
+  input.setCustomValidity(message);
+  input.reportValidity();
+  return false;
+}
+
+function normalizeFriendUsername() {
+  if (!friendUsernameInput) {
+    return "";
+  }
+
+  const cleanedUsername = friendUsernameInput.value.trim().toLowerCase();
+  friendUsernameInput.value = cleanedUsername;
+  return cleanedUsername;
+}
+
+function validateFriendUsername() {
+  if (!friendUsernameInput) {
+    return true;
+  }
+
+  const cleanedUsername = normalizeFriendUsername();
+
+  if (!cleanedUsername) {
+    return showFieldError(friendUsernameInput, "Please enter a username.");
+  }
+
+  if (cleanedUsername.length < MIN_USERNAME_LENGTH) {
+    return showFieldError(
+      friendUsernameInput,
+      `Username must be at least ${MIN_USERNAME_LENGTH} characters.`
+    );
+  }
+
+  if (cleanedUsername.length > MAX_USERNAME_LENGTH) {
+    return showFieldError(
+      friendUsernameInput,
+      `Username must be ${MAX_USERNAME_LENGTH} characters or fewer.`
+    );
+  }
+
+  if (!USERNAME_PATTERN.test(cleanedUsername)) {
+    return showFieldError(
+      friendUsernameInput,
+      "Username can only use lowercase letters, numbers, and underscores."
+    );
+  }
+
+  clearFieldError(friendUsernameInput);
+  return true;
+}
+
 if (friendUsernameInput) {
   friendUsernameInput.focus();
+
+  friendUsernameInput.addEventListener("input", () => {
+    validateFriendUsername();
+  });
 }
 
 if (friendForm && friendUsernameInput) {
   friendForm.addEventListener("submit", (event) => {
-    const cleanedUsername = friendUsernameInput.value.trim().toLowerCase();
+    const isValid = validateFriendUsername();
 
-    if (!cleanedUsername) {
+    if (!isValid) {
       event.preventDefault();
       friendUsernameInput.focus();
       return;
     }
-
-    friendUsernameInput.value = cleanedUsername;
 
     const submitButton = friendForm.querySelector('button[type="submit"]');
 

--- a/static/js/register.js
+++ b/static/js/register.js
@@ -1,14 +1,95 @@
 const authForms = document.querySelectorAll("#login-form, #register-form");
 const guestForms = document.querySelectorAll(".guest-form");
 
+const MIN_USERNAME_LENGTH = 3;
+const MAX_USERNAME_LENGTH = 80;
+const USERNAME_PATTERN = /^[a-z0-9_]+$/;
+
 function normalizeUsernameInput(form) {
   const usernameInput = form.querySelector('input[name="username"]');
 
   if (!usernameInput) {
+    return null;
+  }
+
+  usernameInput.value = usernameInput.value.trim().toLowerCase();
+  return usernameInput;
+}
+
+function clearFieldError(input) {
+  if (!input) {
     return;
   }
 
-  usernameInput.value = usernameInput.value.trim();
+  input.setCustomValidity("");
+}
+
+function showFieldError(input, message) {
+  if (!input) {
+    return false;
+  }
+
+  input.setCustomValidity(message);
+  input.reportValidity();
+  return false;
+}
+
+function validateUsernameInput(input, strictPattern) {
+  if (!input) {
+    return true;
+  }
+
+  const value = input.value.trim().toLowerCase();
+  input.value = value;
+
+  if (!value) {
+    return showFieldError(input, "Please enter a username.");
+  }
+
+  if (value.length < MIN_USERNAME_LENGTH) {
+    return showFieldError(input, `Username must be at least ${MIN_USERNAME_LENGTH} characters.`);
+  }
+
+  if (value.length > MAX_USERNAME_LENGTH) {
+    return showFieldError(input, `Username must be ${MAX_USERNAME_LENGTH} characters or fewer.`);
+  }
+
+  if (strictPattern && !USERNAME_PATTERN.test(value)) {
+    return showFieldError(input, "Username can only use lowercase letters, numbers, and underscores.");
+  }
+
+  clearFieldError(input);
+  return true;
+}
+
+function validatePasswordInput(input) {
+  if (!input) {
+    return true;
+  }
+
+  if (!input.value) {
+    return showFieldError(input, "Please enter a password.");
+  }
+
+  clearFieldError(input);
+  return true;
+}
+
+function validateConfirmPassword(passwordInput, confirmInput) {
+  if (!confirmInput) {
+    return true;
+  }
+
+  if (!confirmInput.value) {
+    return showFieldError(confirmInput, "Please confirm your password.");
+  }
+
+  if (passwordInput && passwordInput.value !== confirmInput.value) {
+    return showFieldError(confirmInput, "Passwords do not match.");
+  }
+
+  clearFieldError(confirmInput);
+  return true;
 }
 
 function setBusyButton(form, buttonText) {
@@ -23,8 +104,46 @@ function setBusyButton(form, buttonText) {
 }
 
 authForms.forEach((form) => {
-  form.addEventListener("submit", () => {
+  const usernameInput = form.querySelector('input[name="username"]');
+  const passwordInput = form.querySelector('input[name="password"]');
+  const confirmInput = form.querySelector('input[name="confirm-password"]');
+  const isRegisterForm = form.id === "register-form";
+
+  if (usernameInput) {
+    usernameInput.addEventListener("input", () => {
+      validateUsernameInput(usernameInput, isRegisterForm);
+    });
+  }
+
+  if (passwordInput) {
+    passwordInput.addEventListener("input", () => {
+      clearFieldError(passwordInput);
+
+      if (confirmInput && confirmInput.value) {
+        validateConfirmPassword(passwordInput, confirmInput);
+      }
+    });
+  }
+
+  if (confirmInput) {
+    confirmInput.addEventListener("input", () => {
+      validateConfirmPassword(passwordInput, confirmInput);
+    });
+  }
+
+  form.addEventListener("submit", (event) => {
     normalizeUsernameInput(form);
+
+    const usernameValid = validateUsernameInput(usernameInput, isRegisterForm);
+    const passwordValid = validatePasswordInput(passwordInput);
+    const confirmValid = validateConfirmPassword(passwordInput, confirmInput);
+
+    if (!usernameValid || !passwordValid || !confirmValid) {
+      event.preventDefault();
+      return;
+    }
+
+    setBusyButton(form, isRegisterForm ? "REGISTERING..." : "LOGGING IN...");
   });
 });
 

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -27,7 +27,13 @@
         <div class="chat-heading">
           <h1 class="chat-header">Chat with {{ friend.display_name or friend.username }}</h1>
           <p class="chat-status" data-chat-status>Connecting live chat...</p>
-          <p class="flash-message chat-alert" data-chat-alert hidden></p>
+          {% with messages = get_flashed_messages() %}
+            {% if messages %}
+              <p class="flash-message chat-alert" data-chat-alert>{{ messages[-1] }}</p>
+            {% else %}
+              <p class="flash-message chat-alert" data-chat-alert hidden></p>
+            {% endif %}
+          {% endwith %}
         </div>
       </div>
 

--- a/templates/friends_view.html
+++ b/templates/friends_view.html
@@ -69,6 +69,12 @@
             name="friend_username"
             placeholder="Enter username"
             required
+            minlength="3"
+            maxlength="80"
+            pattern="[a-z0-9_]+"
+            title="Use lowercase letters, numbers, and underscores only."
+            autocomplete="off"
+            spellcheck="false"
             class="input-text"
             data-friend-username
           >

--- a/templates/login.html
+++ b/templates/login.html
@@ -23,10 +23,26 @@
 
     <form id="login-form" method="POST" action="/login">
       <label for="username">Username</label>
-      <input type="text" id="username" name="username" />
+      <input
+        type="text"
+        id="username"
+        name="username"
+        required
+        minlength="3"
+        maxlength="80"
+        autocomplete="username"
+      />
 
       <label for="password">Password</label>
-      <input type="password" id="password" name="password" />
+      <input
+        type="password"
+        id="password"
+        name="password"
+        required
+        minlength="6"
+        maxlength="255"
+        autocomplete="current-password"
+      />
 
       <button type="submit" class="login-btn">Log In</button>
     </form>

--- a/templates/register.html
+++ b/templates/register.html
@@ -21,13 +21,40 @@
 
     <form id="register-form" method="POST" action="/register">
       <label for="username">Username</label>
-      <input type="text" id="username" name="username" placeholder="Choose a username" />
+      <input
+        type="text"
+        id="username"
+        name="username"
+        placeholder="Choose a username"
+        required
+        minlength="3"
+        maxlength="80"
+        autocomplete="username"
+      />
 
       <label for="password">Password</label>
-      <input type="password" id="password" name="password" placeholder="Create a password" />
+      <input
+        type="password"
+        id="password"
+        name="password"
+        placeholder="Create a password"
+        required
+        minlength="6"
+        maxlength="255"
+        autocomplete="new-password"
+      />
 
       <label for="confirm-password">Confirm Password</label>
-      <input type="password" id="confirm-password" name="confirm-password" placeholder="Confirm your password" />
+      <input
+        type="password"
+        id="confirm-password"
+        name="confirm-password"
+        placeholder="Confirm your password"
+        required
+        minlength="6"
+        maxlength="255"
+        autocomplete="new-password"
+      />
 
       <button type="submit" class="signup-btn">Register</button>
     </form>


### PR DESCRIPTION
Summary
This PR adds stricter validation across auth, friends, chat, and save input handling.

What changed
added HTML validation attributes to login/register forms
added client-side validation for auth forms
added HTML validation attributes to the friends form
added client-side validation for the friends form
added server-side validation for auth routes
added server-side validation for social/chat routes
added server-side sanitising for save payloads
fixed chat so validation feedback is shown in the template
fixed add-friend invalid target feedback so the message is shown on the friends page
Important note
Some old test accounts may no longer work if the username format is unusual.

Usernames are now expected to be:

lowercase only
3 to 80 characters
letters, numbers, and underscores only
Testing done
py_compile passed
login/register validation tested
friends validation tested
chat validation tested
socket chat validation tested
save/load sanitising tested
full automated validation sweep passed
Notes
This branch reduces simple inspect/devtools abuse by validating and sanitising server-side input, but it is not a full anti-cheat rewrite.