### PR TITLE
Improve game UI, add mission feed skip controls, and tune fast zombie damage

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -1410,6 +1410,29 @@ body::before {
   scrollbar-gutter: stable;
 }
 
+.play-page .shop-inventory-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(3, 7, 11, 0.55);
+  color: rgba(255, 255, 255, 0.84);
+  font-size: 0.62rem;
+  line-height: 1.35;
+}
+
+.play-page .shop-inventory-summary span,
+.play-page .shop-resource-line {
+  overflow-wrap: anywhere;
+}
+
+.play-page .shop-resource-line {
+  opacity: 0.95;
+}
+
 .play-page .shop-box .choice-buttons {
   gap: 12px;
 }

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -671,6 +671,12 @@ body::before {
   min-height: 0;
 }
 
+.play-page .game-main.shop-choice-scroll {
+  overflow-y: auto;
+  padding-right: 8px;
+  scrollbar-gutter: stable;
+}
+
 .play-page .top-game-row {
   display: grid;
   grid-template-columns: 1fr;
@@ -1510,6 +1516,20 @@ body::before {
   overflow: hidden;
   background: linear-gradient(180deg, rgba(8, 10, 15, 0.82), rgba(3, 4, 8, 0.9));
   backdrop-filter: blur(4px);
+}
+
+.play-page .game-main.shop-choice-scroll .top-game-row,
+.play-page .game-main.shop-choice-scroll .path-choice-box,
+.play-page .game-main.shop-choice-scroll .shop-box {
+  flex: 0 0 auto;
+}
+
+.play-page .game-main.shop-choice-scroll .graphics-area {
+  height: clamp(220px, 32vh, 280px);
+}
+
+.play-page .game-main.shop-choice-scroll .shop-box {
+  overflow: visible;
 }
 
 .play-page .emergency-prompt {

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -1184,6 +1184,37 @@ body::before {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 0 32px var(--battle-edge-glow);
 }
 
+.play-page .mission-feed-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.play-page .mission-skip-btn {
+  flex: 0 0 auto;
+  min-width: 112px;
+  padding: 6px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #f4f7fa;
+  font-family: "Silkscreen", monospace;
+  font-size: 0.54rem;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+
+.play-page .mission-skip-btn:hover:not(:disabled),
+.play-page .mission-skip-btn.is-fast-forwarding {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.play-page .mission-skip-btn:disabled {
+  cursor: default;
+  opacity: 0.36;
+}
+
 .play-page .story-text {
   max-width: 100%;
   margin-top: 4px;

--- a/static/js/combat-engine.js
+++ b/static/js/combat-engine.js
@@ -339,6 +339,40 @@ function getSellValue(cost) {
   return Math.max(1, Math.round(cost * 0.6));
 }
 
+function getTotalWeaponAmmo(weapon) {
+  return (weapon.ammoInGun || 0) + (weapon.ammoInBag || 0);
+}
+
+function getShopResourceLine(item, state) {
+  if (item.id === "medkit") {
+    return `Current: ${state.inventory.medKits} medkit${state.inventory.medKits === 1 ? "" : "s"}.`;
+  }
+
+  if (item.id === "pistolAmmo") {
+    return (
+      `Current: ${getTotalWeaponAmmo(state.pistol)} pistol ammo ` +
+      `(${state.pistol.ammoInGun}/${state.pistol.magCapacity} loaded, ${state.pistol.ammoInBag} reserve).`
+    );
+  }
+
+  if (item.id === "rifle") {
+    return state.rifle.owned
+      ? `Current: rifle owned with ${getTotalWeaponAmmo(state.rifle)} total ammo.`
+      : "Current: no rifle owned.";
+  }
+
+  if (item.id === "rifleAmmo") {
+    return state.rifle.owned
+      ? (
+          `Current: ${getTotalWeaponAmmo(state.rifle)} rifle ammo ` +
+          `(${state.rifle.ammoInGun}/${state.rifle.magCapacity} loaded, ${state.rifle.ammoInBag} reserve).`
+        )
+      : "Current: buy the rifle before stocking rifle mags.";
+  }
+
+  return "";
+}
+
 export function createNewGameState({ difficulty = "EASY", seed, character = "leon" } = {}) {
   const rng = createRng(seed);
   const diff = difficulty.toUpperCase();
@@ -1819,6 +1853,7 @@ export function createCombatEngine({ difficulty = "EASY", seed, character = "leo
           id: item.id,
           label: item.label,
           description: item.description,
+          resourceLine: getShopResourceLine(item, state),
           cost: item.cost,
           sellValue: getSellValue(item.cost),
           disabled: !item.canBuy(state)

--- a/static/js/combat-engine.js
+++ b/static/js/combat-engine.js
@@ -35,6 +35,7 @@ const RULES = {
   quiteSidearmDamage: [28, 34],
   rifleDamage: [33, 39],
   knifePercentOfBaseHp: 0.34,
+  fastZombieKnifeBonusDamage: 4,
   knifeSelfDamage: 3,
   leonAxeTriggerChance: 0.33,
   leonAxeSelfDamage: 4,
@@ -1020,6 +1021,10 @@ function resolveWeaponHit(state, rng, weaponKey, baseDamage) {
 
   if (weaponKey === "knife" && enemy.lightDamageResistance < 1) {
     damage *= enemy.lightDamageResistance;
+  }
+
+  if (weaponKey === "knife" && enemy.type === "fast") {
+    damage += RULES.fastZombieKnifeBonusDamage;
   }
 
   let crit = false;

--- a/static/js/gameUI.js
+++ b/static/js/gameUI.js
@@ -245,20 +245,95 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function typeWriter(target, text, speed = 24, isStale = () => false) {
+function getTextElements(target) {
+  return (Array.isArray(target) ? target : [target]).filter(Boolean);
+}
+
+function setTextContent(elements, text) {
+  elements.forEach((element) => {
+    element.textContent = text;
+  });
+}
+
+function createTextPlaybackController() {
+  return {
+    active: false,
+    fastForwarding: false,
+    skipRequested: false,
+
+    start() {
+      this.active = true;
+      this.skipRequested = false;
+      this.fastForwarding = false;
+    },
+
+    stop() {
+      this.active = false;
+      this.skipRequested = false;
+      this.fastForwarding = false;
+    },
+
+    setFastForwarding(isFastForwarding) {
+      if (!this.active) {
+        this.fastForwarding = false;
+        return;
+      }
+
+      this.fastForwarding = isFastForwarding;
+    },
+
+    requestSkip() {
+      if (this.active) {
+        this.skipRequested = true;
+      }
+    },
+
+    getDelay(baseDelay) {
+      return this.fastForwarding ? Math.max(1, baseDelay / 2) : baseDelay;
+    }
+  };
+}
+
+async function sleepWithPlayback(baseDelay, playbackController, isStale = () => false) {
+  let remaining = baseDelay;
+
+  while (remaining > 0) {
+    if (isStale()) return "stale";
+    if (playbackController?.skipRequested) return "skip";
+
+    const delay = Math.min(playbackController?.getDelay(remaining) ?? remaining, 40);
+    await sleep(delay);
+    remaining -= playbackController?.fastForwarding ? delay * 2 : delay;
+  }
+
+  return "done";
+}
+
+async function typeWriter(target, text, speed = 24, isStale = () => false, playbackController = null) {
   const elements = (Array.isArray(target) ? target : [target]).filter(Boolean);
   if (elements.length === 0) return;
 
-  elements.forEach((element) => {
-    element.textContent = "";
-  });
+  setTextContent(elements, "");
+
   for (let i = 0; i < text.length; i += 1) {
-    if (isStale()) return;
-    elements.forEach((element) => {
-      element.textContent += text[i];
-    });
-    await sleep(speed);
+    if (isStale()) return "stale";
+    if (playbackController?.skipRequested) {
+      setTextContent(elements, text);
+      return "skip";
+    }
+
+    setTextContent(elements, `${elements[0].textContent}${text[i]}`);
+
+    const sleepResult = await sleepWithPlayback(speed, playbackController, isStale);
+    if (sleepResult !== "done") {
+      if (sleepResult === "skip") {
+        setTextContent(elements, text);
+      }
+      return sleepResult;
+    }
   }
+
+  return "done";
 }
 
 function appendCombatLog(text) {
@@ -275,15 +350,53 @@ function appendCombatLog(text) {
   }
 }
 
-async function playEventSequence(element, events, speed = 24, pause = 460, isStale = () => false) {
+async function playEventSequence(
+  element,
+  events,
+  speed = 24,
+  pause = 460,
+  isStale = () => false,
+  playbackController = null
+) {
   if (!events || events.length === 0) return;
 
-  for (const eventText of events) {
+  const elements = getTextElements(element);
+
+  for (let index = 0; index < events.length; index += 1) {
     if (isStale()) return;
-    await typeWriter(element, eventText, speed, isStale);
+    const eventText = events[index];
+    const typeResult = await typeWriter(elements, eventText, speed, isStale, playbackController);
     if (isStale()) return;
     appendCombatLog(eventText);
-    await sleep(pause);
+
+    if (typeResult === "skip" || playbackController?.skipRequested) {
+      for (let remainingIndex = index + 1; remainingIndex < events.length; remainingIndex += 1) {
+        const remainingText = events[remainingIndex];
+        setTextContent(elements, remainingText);
+        appendCombatLog(remainingText);
+      }
+
+      if (playbackController) {
+        playbackController.skipRequested = false;
+      }
+
+      return;
+    }
+
+    const pauseResult = await sleepWithPlayback(pause, playbackController, isStale);
+    if (pauseResult === "skip") {
+      for (let remainingIndex = index + 1; remainingIndex < events.length; remainingIndex += 1) {
+        const remainingText = events[remainingIndex];
+        setTextContent(elements, remainingText);
+        appendCombatLog(remainingText);
+      }
+
+      if (playbackController) {
+        playbackController.skipRequested = false;
+      }
+
+      return;
+    }
   }
 }
 
@@ -1158,6 +1271,8 @@ export function bootGameUI({
 
   const storyText = $("#story-text");
   const shopStoryText = $("#shop-story-text");
+  const storySkipBtn = $("#story-skip-btn");
+  const shopStorySkipBtn = $("#shop-story-skip-btn");
   const emergencyBox = $("#emergency-box");
   const emergencyTitle = $("#emergency-title");
   const emergencyPrompt = $("#emergency-prompt");
@@ -1170,6 +1285,7 @@ export function bootGameUI({
   let locked = false;
   let isAnimatingEvents = false;
   let storyRenderId = 0;
+  const textPlaybackController = createTextPlaybackController();
   const battleSceneState = {
     lastActionKey: "idle",
     activeWeaponKey: "pistol",
@@ -1278,6 +1394,15 @@ export function bootGameUI({
     if (shopStoryText) {
       shopStoryText.textContent = text;
     }
+  }
+
+  function updateMissionSkipControls() {
+    [storySkipBtn, shopStorySkipBtn].forEach((button) => {
+      if (!button) return;
+
+      button.disabled = !isAnimatingEvents;
+      button.classList.toggle("is-fast-forwarding", textPlaybackController.fastForwarding);
+    });
   }
 
   function areMainActionsLocked() {
@@ -1427,19 +1552,29 @@ export function bootGameUI({
     renderContinueBox(engine, interactionLocked, handleContinueLevel);
     renderEmergencyBox();
     updateActionAvailability();
+    updateMissionSkipControls();
   }
 
   async function runAndRender(events) {
     const renderId = ++storyRenderId;
     isAnimatingEvents = true;
+    textPlaybackController.start();
     renderAll();
-    await playEventSequence([storyText, shopStoryText], events, 24, 460, () => renderId !== storyRenderId);
+    await playEventSequence(
+      [storyText, shopStoryText],
+      events,
+      24,
+      460,
+      () => renderId !== storyRenderId,
+      textPlaybackController
+    );
 
     if (renderId !== storyRenderId) {
       return;
     }
 
     isAnimatingEvents = false;
+    textPlaybackController.stop();
     renderAll();
   }
 
@@ -1566,6 +1701,57 @@ export function bootGameUI({
     registerEmergencyPress();
   }
 
+  function bindMissionSkipButton(button) {
+    if (!button) return;
+
+    let pointerStartedAt = 0;
+    let pointerActive = false;
+    let suppressNextClick = false;
+
+    const stopFastForwarding = () => {
+      if (!pointerActive) return;
+
+      pointerActive = false;
+      if (performance.now() - pointerStartedAt > 180) {
+        suppressNextClick = true;
+      }
+
+      textPlaybackController.setFastForwarding(false);
+      updateMissionSkipControls();
+    };
+
+    button.addEventListener("pointerdown", (event) => {
+      if (button.disabled) return;
+
+      pointerStartedAt = performance.now();
+      pointerActive = true;
+      textPlaybackController.setFastForwarding(true);
+      updateMissionSkipControls();
+
+      try {
+        button.setPointerCapture(event.pointerId);
+      } catch {
+        // Pointer capture is best-effort; the button still works without it.
+      }
+    });
+
+    button.addEventListener("pointerup", stopFastForwarding);
+    button.addEventListener("pointercancel", stopFastForwarding);
+    button.addEventListener("pointerleave", stopFastForwarding);
+
+    button.addEventListener("click", () => {
+      if (button.disabled) return;
+
+      if (suppressNextClick) {
+        suppressNextClick = false;
+        return;
+      }
+
+      textPlaybackController.requestSkip();
+      updateMissionSkipControls();
+    });
+  }
+
   const attackBtn = $("#attack-btn");
   const defendBtn = $("#defend-btn");
   const inventoryBtn = $("#inventory-btn");
@@ -1582,6 +1768,9 @@ export function bootGameUI({
   const shieldBtn = $("#shield-btn");
   const inventoryBackBtn = $("#inventory-back-btn");
   const statsBackBtn = $("#stats-back-btn");
+
+  bindMissionSkipButton(storySkipBtn);
+  bindMissionSkipButton(shopStorySkipBtn);
 
   if (attackBtn) {
     attackBtn.addEventListener("click", () => {

--- a/static/js/gameUI.js
+++ b/static/js/gameUI.js
@@ -987,6 +987,7 @@ function renderShopBox(engine, locked, onBuy, onSell, onContinue) {
   const shopBox = $("#shop-box");
   const buyButtons = $("#shop-buy-buttons");
   const sellButtons = $("#shop-sell-buttons");
+  const inventorySummary = $("#shop-inventory-summary");
   const continueBtn = $("#shop-continue-btn");
   if (!shopBox || !buyButtons || !sellButtons || !continueBtn) return;
 
@@ -997,14 +998,29 @@ function renderShopBox(engine, locked, onBuy, onSell, onContinue) {
     shopBox.style.display = "none";
     buyButtons.innerHTML = "";
     sellButtons.innerHTML = "";
+    if (inventorySummary) {
+      inventorySummary.innerHTML = "";
+    }
     return;
   }
 
   const coins = engine.state.inventory.coins;
+  const { inventory, pistol, rifle } = engine.state;
+  const pistolTotalAmmo = pistol.ammoInGun + pistol.ammoInBag;
+  const rifleTotalAmmo = rifle.ammoInGun + rifle.ammoInBag;
   gameMain?.classList.add("shop-open");
   shopBox.style.display = "flex";
   buyButtons.innerHTML = "";
   sellButtons.innerHTML = "";
+
+  if (inventorySummary) {
+    inventorySummary.innerHTML = `
+      <span>Total pistol ammo with you: ${pistolTotalAmmo}</span>
+      <span>Total rifle ammo with you: ${rifle.owned ? rifleTotalAmmo : "no rifle"}</span>
+      <span>Grenades with you: ${inventory.grenades}</span>
+      <span>Medkits with you: ${inventory.medKits}</span>
+    `;
+  }
 
   engine.getShopInventory().forEach((item) => {
     const button = document.createElement("button");
@@ -1014,6 +1030,7 @@ function renderShopBox(engine, locked, onBuy, onSell, onContinue) {
     button.innerHTML = `
       <span class="choice-title">${item.label} - ${item.cost}C</span>
       <span class="choice-desc">${item.description}</span>
+      ${item.resourceLine ? `<span class="choice-desc shop-resource-line">${item.resourceLine}</span>` : ""}
     `;
     button.addEventListener("click", () => onBuy(item.id));
     buyButtons.appendChild(button);

--- a/static/js/gameUI.js
+++ b/static/js/gameUI.js
@@ -1544,6 +1544,13 @@ export function bootGameUI({
 
   function renderAll() {
     const interactionLocked = isInteractionLocked();
+    const bothShopAndChoicesOpen = engine.isShopOpen() && engine.hasChoices();
+    const gameMain = document.querySelector(".game-main");
+
+    if (gameMain) {
+      gameMain.classList.toggle("shop-choice-scroll", bothShopAndChoicesOpen);
+    }
+
     renderStats(engine);
     renderBattleScene(engine, battleSceneState);
     renderWeaponVisibility(engine);
@@ -1752,6 +1759,45 @@ export function bootGameUI({
     });
   }
 
+  function isEditableTarget(target) {
+    return (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      target?.isContentEditable
+    );
+  }
+
+  const shiftSkipState = {
+    active: false,
+    startedAt: 0
+  };
+
+  function handleMissionSkipKeydown(event) {
+    if (event.code !== "ShiftLeft") return;
+    if (event.repeat || isEditableTarget(event.target) || !textPlaybackController.active) return;
+
+    event.preventDefault();
+    shiftSkipState.active = true;
+    shiftSkipState.startedAt = performance.now();
+    textPlaybackController.setFastForwarding(true);
+    updateMissionSkipControls();
+  }
+
+  function handleMissionSkipKeyup(event) {
+    if (event.code !== "ShiftLeft" || !shiftSkipState.active) return;
+
+    event.preventDefault();
+    shiftSkipState.active = false;
+    textPlaybackController.setFastForwarding(false);
+
+    if (textPlaybackController.active && performance.now() - shiftSkipState.startedAt <= 180) {
+      textPlaybackController.requestSkip();
+    }
+
+    updateMissionSkipControls();
+  }
+
   const attackBtn = $("#attack-btn");
   const defendBtn = $("#defend-btn");
   const inventoryBtn = $("#inventory-btn");
@@ -1874,6 +1920,8 @@ export function bootGameUI({
   }
 
   window.addEventListener("keydown", handleEmergencyKeydown);
+  window.addEventListener("keydown", handleMissionSkipKeydown);
+  window.addEventListener("keyup", handleMissionSkipKeyup);
 
   async function startGame() {
     showMainActions();

--- a/templates/play.html
+++ b/templates/play.html
@@ -264,6 +264,7 @@
           <div class="shop-grid">
             <div>
               <h3>BUY</h3>
+              <div id="shop-inventory-summary" class="shop-inventory-summary"></div>
               <div id="shop-buy-buttons" class="choice-buttons"></div>
             </div>
             <div>

--- a/templates/play.html
+++ b/templates/play.html
@@ -224,7 +224,16 @@
                 <div id="battle-tags" class="battle-tags"></div>
 
                 <div class="battle-caption">
-                  <span class="battle-caption-label">MISSION FEED</span>
+                  <div class="mission-feed-heading">
+                    <span class="battle-caption-label">MISSION FEED</span>
+                    <button
+                      type="button"
+                      id="story-skip-btn"
+                      class="mission-skip-btn"
+                      aria-label="Skip mission feed text, or hold to play text at double speed"
+                      disabled
+                    >SKIP / HOLD 2X</button>
+                  </div>
                   <div id="story-text" class="story-text">Mission starting...</div>
                 </div>
               </div>
@@ -258,7 +267,16 @@
             <button type="button" id="shop-continue-btn" class="secondary-btn">CONTINUE</button>
           </div>
           <div class="shop-dialogue">
-            <span class="battle-caption-label">MISSION FEED</span>
+            <div class="mission-feed-heading">
+              <span class="battle-caption-label">MISSION FEED</span>
+              <button
+                type="button"
+                id="shop-story-skip-btn"
+                class="mission-skip-btn"
+                aria-label="Skip shop mission feed text, or hold to play text at double speed"
+                disabled
+              >SKIP / HOLD 2X</button>
+            </div>
             <div id="shop-story-text" class="story-text">Mission starting...</div>
           </div>
           <div class="shop-grid">


### PR DESCRIPTION
## Summary

This PR updates the game UI to make combat and shop interactions smoother and easier to follow.

Most of the changes are UI-focused, including improved mission feed controls, better shop resource visibility, and layout fixes for screens where the shop and choice buttons are both visible. It also adds a skip/fast-forward button for mission text so players do not have to wait through every typed message.

## Changes

- Added `SKIP / HOLD 2X` controls to the mission feed and shop mission feed
- Added click-to-skip and hold-to-fast-forward behavior for animated story text
- Added Left Shift keyboard support for skipping/fast-forwarding mission feed text
- Improved shop UI so players can see their current ammo, grenades, and medkits before buying
- Added extra resource details to shop items, such as loaded/reserve ammo counts
- Fixed shop/choice layout scrolling so overlapping UI is easier to navigate
- Slightly adjusted knife damage against fast zombies so fighting them feels a bit fairer

## Testing

- Compared branch against `origin/main`
- Reviewed the changed UI/combat files:
  - `templates/play.html`
  - `static/css/global.css`
  - `static/js/gameUI.js`
  - `static/js/combat-engine.js`
<img width="1452" height="750" alt="Screenshot 2026-04-27 at 3 08 21 PM" src="https://github.com/user-attachments/assets/2b087fa5-0551-4af7-8630-864919150464" />
