### PR TITLE
fix: stabilize auth, chat, and profile actions

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,7 @@ PROFILE_IMAGE_UPLOAD_PREFIX = "uploads/profile_pics/"
 PROFILE_IMAGE_ALLOWED_EXTENSIONS = {".jpg", ".jpeg"}
 PROFILE_IMAGE_UPLOAD_MAX_BYTES = 5 * 1024 * 1024
 ONLINE_WINDOW = timedelta(minutes=2)
+PRESENCE_REFRESH_INTERVAL = timedelta(seconds=30)
 PROFILE_IMAGE_OPTIONS = [
     {"label": "Shadows", "filename": PROFILE_IMAGE_DEFAULT},
     {"label": "Leon", "filename": "images/players/leon_idle.png"},
@@ -274,6 +275,12 @@ app.config["SQLALCHEMY_DATABASE_URI"] = configure_sqlcipher_database_uri(
     sqlcipher_database_key
 )
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
+    "pool_pre_ping": True,
+    "connect_args": {
+        "timeout": 30,
+    },
+}
 app.config["SESSION_COOKIE_HTTPONLY"] = True
 app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
 app.config["SESSION_COOKIE_SECURE"] = (
@@ -326,6 +333,37 @@ def verify_sqlcipher_database():
         raise RuntimeError("SQLCipher is not active for the configured SQLite database.")
 
     db.session.execute(text("SELECT count(*) FROM sqlite_master")).scalar()
+
+
+def rollback_database_session(context):
+    try:
+        db.session.rollback()
+        return True
+    except SQLAlchemyError as rollback_error:
+        app.logger.warning(
+            "%s rollback failed. %s",
+            context,
+            getattr(rollback_error, "orig", rollback_error)
+        )
+    except Exception as rollback_error:
+        app.logger.warning("%s rollback failed. %s", context, rollback_error)
+
+    try:
+        db.session.remove()
+    except Exception as remove_error:
+        app.logger.warning("%s session reset failed. %s", context, remove_error)
+
+    return False
+
+
+def parse_iso_datetime(value):
+    if not value:
+        return None
+
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
 
 
 def ensure_user_schema():
@@ -429,7 +467,7 @@ def initialize_runtime_database():
             ensure_save_data_schema()
             ensure_message_schema()
         except SQLAlchemyError as error:
-            db.session.rollback()
+            rollback_database_session("Database initialization")
             app.logger.warning(
                 "Database initialization skipped because SQLite is unavailable. %s",
                 getattr(error, "orig", error)
@@ -441,16 +479,32 @@ if not is_flask_db_command():
 
 @app.before_request
 def refresh_current_user_presence():
+    if request.endpoint == "static" or request.path.startswith("/socket.io"):
+        return
+
     user_id = session.get("user_id")
 
     if user_id is None or session.get("is_guest"):
         return
 
+    now = datetime.utcnow()
+    last_presence_refresh = parse_iso_datetime(session.get("last_presence_refresh_at"))
+
+    if (
+        last_presence_refresh is not None
+        and now - last_presence_refresh < PRESENCE_REFRESH_INTERVAL
+    ):
+        return
+
     try:
-        User.query.filter_by(id=user_id).update({"last_seen": datetime.utcnow()})
+        User.query.filter_by(id=user_id).update(
+            {"last_seen": now},
+            synchronize_session=False
+        )
         db.session.commit()
+        session["last_presence_refresh_at"] = now.isoformat()
     except SQLAlchemyError as error:
-        db.session.rollback()
+        rollback_database_session("Presence update")
         app.logger.warning(
             "Presence update failed for user %s. %s",
             user_id,
@@ -610,7 +664,7 @@ def get_latest_save_payload(user_id):
     try:
         payloads = list_db_save_payloads(user_id)
     except SQLAlchemyError:
-        db.session.rollback()
+        rollback_database_session("Latest save query")
         payloads = []
 
     payloads.extend(list_fallback_save_payloads(user_id))
@@ -1045,7 +1099,7 @@ def get_leaderboard_entries(current_user_id=None, limit=None, user_ids=None):
             .all()
         )
     except SQLAlchemyError as error:
-        db.session.rollback()
+        rollback_database_session("Leaderboard query")
         app.logger.warning(
             "Leaderboard query failed. %s",
             getattr(error, "orig", error)

--- a/routes.py
+++ b/routes.py
@@ -156,6 +156,11 @@ def sanitize_save_request_payload(data):
 @app.route("/")
 @app.route("/login", methods=["GET", "POST"])
 def show_login():
+    if request.method == "GET" and request.path == "/login" and current_user.is_authenticated:
+        logout_user()
+        session.clear()
+        return render_template("login.html", error=None)
+
     if current_user.is_authenticated:
         return redirect(url_for("main_menu"))
 
@@ -424,7 +429,7 @@ def profile():
                 allow_friend_messages_value = bool(user.allow_friend_messages)
                 hide_from_leaderboard_value = bool(user.hide_from_leaderboard)
             except SQLAlchemyError as update_error:
-                db.session.rollback()
+                rollback_database_session("Profile update")
                 if new_uploaded_profile_image is not None:
                     delete_uploaded_profile_image(new_uploaded_profile_image)
                 app.logger.warning(
@@ -521,7 +526,7 @@ def view_profile(user_id):
 
             db.session.commit()
         except SQLAlchemyError as error:
-            db.session.rollback()
+            rollback_database_session("Profile action")
             app.logger.warning(
                 "Profile friend action failed for user %s and profile %s. %s",
                 current_user_id,
@@ -627,7 +632,7 @@ def save_game():
         unlocked_achievements = unlock_achievements_for_user(session["user_id"])
         db.session.commit()
     except SQLAlchemyError as error:
-        db.session.rollback()
+        rollback_database_session("Save game")
 
         try:
             write_fallback_save(user_id, character_id, fallback_payload)
@@ -678,7 +683,7 @@ def load_game():
     try:
         db_payloads = list_db_save_payloads(user_id, character_id=character_id)
     except SQLAlchemyError as error:
-        db.session.rollback()
+        rollback_database_session("Load game")
         app.logger.warning(
             "Database load failed for user %s; falling back to JSON save. %s",
             user_id,
@@ -727,7 +732,7 @@ def add_friend(user_id):
         db.session.commit()
         flash(message)
     except SQLAlchemyError as error:
-        db.session.rollback()
+        rollback_database_session("Friend request")
         app.logger.warning(
             "Friend request failed for user %s and target %s. %s",
             current_user_id,
@@ -765,7 +770,7 @@ def show_friends():
                 db.session.commit()
                 flash(message)
             except SQLAlchemyError as error:
-                db.session.rollback()
+                rollback_database_session("Friend request")
                 app.logger.warning(
                     "Friend request failed for user %s and target %s. %s",
                     from_user_id,
@@ -850,7 +855,7 @@ def unfriend(friend_id):
         db.session.commit()
         flash(f"Removed {get_display_name(friend)} from your friends.")
     except SQLAlchemyError as error:
-        db.session.rollback()
+        rollback_database_session("Unfriend")
         app.logger.warning(
             "Unfriend failed for user %s and friend %s. %s",
             current_user_id,
@@ -888,6 +893,35 @@ def chat_keys(friend_id):
         "ok": True,
         "current_user_key": serialize_chat_public_key(user),
         "friend_key": serialize_chat_public_key(friend),
+    })
+
+@app.route("/chat/keys", methods=["POST"])
+@login_required
+def register_chat_key():
+    user = current_user._get_current_object()
+    data = request.get_json(silent=True) or {}
+    public_key = str(data.get("public_key", "")).strip()
+
+    if not public_key:
+        return jsonify({"ok": False, "message": "Chat public key is required."}), 400
+
+    try:
+        user.chat_public_key = public_key
+        user.chat_key_id = build_chat_key_id(public_key)
+        user.chat_key_created_at = datetime.utcnow()
+        db.session.commit()
+    except SQLAlchemyError as error:
+        rollback_database_session("Chat key registration")
+        app.logger.warning(
+            "Chat key registration failed for user %s. %s",
+            user.id,
+            getattr(error, "orig", error)
+        )
+        return jsonify({"ok": False, "message": "Chat key registration failed."}), 500
+
+    return jsonify({
+        "ok": True,
+        "current_user_key": serialize_chat_public_key(user),
     })
 
 @app.route("/chat/<int:friend_id>", methods=["GET", "POST"])

--- a/static/js/chat-identity.js
+++ b/static/js/chat-identity.js
@@ -1,0 +1,95 @@
+(() => {
+  const page = document.body;
+  const csrfTokenMeta = document.querySelector('meta[name="csrf-token"]');
+  const currentUserId = Number(page?.dataset.userId || page?.dataset.currentUserId || 0);
+  const encoder = new TextEncoder();
+
+  if (!currentUserId || !window.crypto?.subtle) {
+    return;
+  }
+
+  function bytesToBase64Url(bytes) {
+    const binary = Array.from(new Uint8Array(bytes), (byte) => String.fromCharCode(byte)).join("");
+    return window.btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+  }
+
+  function base64UrlToBytes(value) {
+    const padded = `${value}${"=".repeat((4 - (value.length % 4)) % 4)}`;
+    const binary = window.atob(padded.replaceAll("-", "+").replaceAll("_", "/"));
+    return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  }
+
+  async function hashKeyId(publicKey) {
+    const digest = await crypto.subtle.digest("SHA-256", encoder.encode(publicKey));
+    return Array.from(new Uint8Array(digest))
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("")
+      .slice(0, 32);
+  }
+
+  function getStorageKey() {
+    return `cits3403:e2ee:${currentUserId}`;
+  }
+
+  async function importPrivateKey(privateKey) {
+    return crypto.subtle.importKey(
+      "pkcs8",
+      base64UrlToBytes(privateKey),
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      ["deriveKey"]
+    );
+  }
+
+  async function exportOwnKeys(keyPair) {
+    const publicKey = bytesToBase64Url(await crypto.subtle.exportKey("spki", keyPair.publicKey));
+    const privateKey = bytesToBase64Url(await crypto.subtle.exportKey("pkcs8", keyPair.privateKey));
+
+    return {
+      publicKey,
+      privateKey,
+      keyId: await hashKeyId(publicKey),
+    };
+  }
+
+  async function loadOrCreateOwnKeyRecord() {
+    const saved = window.localStorage.getItem(getStorageKey());
+
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (parsed.publicKey && parsed.privateKey && parsed.keyId) {
+          await importPrivateKey(parsed.privateKey);
+          return parsed;
+        }
+      } catch {
+        window.localStorage.removeItem(getStorageKey());
+      }
+    }
+
+    const keyPair = await crypto.subtle.generateKey(
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      ["deriveKey"]
+    );
+    const exported = await exportOwnKeys(keyPair);
+    window.localStorage.setItem(getStorageKey(), JSON.stringify(exported));
+    return exported;
+  }
+
+  async function registerChatKey() {
+    const ownKeyRecord = await loadOrCreateOwnKeyRecord();
+    const csrfToken = csrfTokenMeta?.content || "";
+
+    await fetch("/chat/keys", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
+      },
+      body: JSON.stringify({ public_key: ownKeyRecord.publicKey }),
+    });
+  }
+
+  registerChatKey().catch(() => {});
+})();

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -127,7 +127,7 @@ async function deriveMessageKey(peerPublicKey) {
 async function encryptMessage(plainText) {
   const freshFriendKey = await ensureFriendKey();
   if (!freshFriendKey) {
-    throw new Error("Friend encryption key is not available yet.");
+    throw new Error("Friend chat key is not ready yet. Ask them to log in once, then try again.");
   }
 
   const key = await deriveMessageKey(freshFriendKey.public_key);
@@ -285,7 +285,10 @@ function pollFriendKey() {
   }
 
   window.setTimeout(async () => {
-    await ensureFriendKey();
+    const freshFriendKey = await ensureFriendKey();
+    if (freshFriendKey) {
+      clearChatAlert();
+    }
     pollFriendKey();
   }, 1000);
 }

--- a/templates/friends_view.html
+++ b/templates/friends_view.html
@@ -4,13 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ username }}'s Friends</title>
+  <meta name="csrf-token" content="{{ csrf_token() }}">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Silkscreen:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}" />
 </head>
-<body class="play-page friends-page">
+<body class="play-page friends-page" data-user-id="{{ current_user.id }}">
   <div class="screen-wrap">
     <section class="panel active">
       <a href="{{ url_for('main_menu') }}" class="back-arrow" aria-label="Back to main menu"></a>
@@ -73,6 +74,7 @@
                 class="inline-action-form"
                 onsubmit="return confirm('Remove {{ (f.display_name or f.username)|e }} from your friends?');"
               >
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="danger-btn">Unfriend</button>
               </form>
             </li>
@@ -131,6 +133,7 @@
     </section>
   </div>
 
+  <script src="{{ url_for('static', filename='js/chat-identity.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/friends-page.js') }}" defer></script>
 </body>
 </html>

--- a/templates/main_menu_view.html
+++ b/templates/main_menu_view.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Main Menu</title>
+  <meta name="csrf-token" content="{{ csrf_token() }}">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -104,6 +105,7 @@
   </div>
 
   <script src="{{ url_for('static', filename='js/friends-menu.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='js/chat-identity.js') }}" defer></script>
 
   <div id="settings-modal" class="settings-modal" hidden aria-hidden="true">
     <div class="settings-modal-panel" role="dialog" aria-modal="true" aria-labelledby="settings-title">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -4,13 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Customize Profile</title>
+  <meta name="csrf-token" content="{{ csrf_token() }}">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Silkscreen:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}">
 </head>
-<body class="achievements-page profile-page">
+<body class="achievements-page profile-page" data-user-id="{{ current_user.id }}">
   <div class="menu-container">
     <a href="{{ url_for('main_menu') }}" class="back-arrow" aria-label="Back to main menu"></a>
 
@@ -206,5 +207,6 @@
       </form>
     </div>
   </div>
+  <script src="{{ url_for('static', filename='js/chat-identity.js') }}" defer></script>
 </body>
 </html>

--- a/templates/public_profile.html
+++ b/templates/public_profile.html
@@ -4,13 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ display_name }}'s Profile</title>
+  <meta name="csrf-token" content="{{ csrf_token() }}">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Silkscreen:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}">
 </head>
-<body class="achievements-page profile-page public-profile-page">
+<body class="achievements-page profile-page public-profile-page" data-user-id="{{ current_user.id }}">
   <div class="menu-container">
     <a href="{{ url_for('main_menu') }}" class="back-arrow" aria-label="Back to main menu"></a>
 
@@ -107,6 +108,7 @@
         <div class="profile-reaction-row">
           {% for reaction in reaction_options %}
             <form method="POST" action="{{ url_for('view_profile', user_id=profile_user.id) }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <input type="hidden" name="action" value="profile_reaction">
               <input type="hidden" name="reaction_type" value="{{ reaction.value }}">
               <button
@@ -125,6 +127,7 @@
       <section class="profile-section">
         <h2>Comments</h2>
         <form method="POST" action="{{ url_for('view_profile', user_id=profile_user.id) }}" class="profile-comment-form">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" name="action" value="profile_comment">
           <textarea
             name="comment"
@@ -163,6 +166,7 @@
               action="{{ url_for('unfriend', friend_id=profile_user.id) }}"
               onsubmit="return confirm('Remove {{ display_name|e }} from your friends?');"
             >
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button type="submit" class="public-profile-action-btn danger-btn">UNFRIEND</button>
             </form>
           </div>
@@ -182,5 +186,6 @@
       </section>
     </div>
   </div>
+  <script src="{{ url_for('static', filename='js/chat-identity.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

This PR fixes several user-facing issues found during profile, friends, login, and chat flows.

## Changes

- Added safe database rollback handling so SQLCipher closed-connection errors do not crash the app.
- Reduced unnecessary presence updates by throttling refreshes and skipping static/socket requests.
- Added missing CSRF tokens to profile reactions, profile comments, and unfriend forms.
- Updated `/login` so visiting it directly clears an existing saved browser session and shows the login page.
- Added proactive chat key registration from logged-in pages so friends can send encrypted messages without both users opening chat first.
- Improved the chat error message when a friend has not published a chat key yet.

## Testing

- Ran Python syntax checks.
- Ran `npm run sanity:js`.
- Verified profile update flow against a temporary SQLCipher database.
- Verified friends/profile CSRF actions.
- Verified login cookie clearing and chat key registration flow.
<img width="1205" height="1289" alt="image" src="https://github.com/user-attachments/assets/790b269b-2487-4035-a934-ed7b87fecda7" />
<img width="1148" height="796" alt="image" src="https://github.com/user-attachments/assets/afc01693-d3d2-4f55-abbf-7b2918be203b" />

