### PR TITLE
Stabilize sanity checks and isolate browser test servers

### DIFF
--- a/SANITY_CHECKS.md
+++ b/SANITY_CHECKS.md
@@ -331,7 +331,7 @@ It checks real browser flows such as:
 How it works:
 
 - `playwright.config.js` starts `scripts/run_playwright_server.py`.
-- The Flask app runs on `http://127.0.0.1:5000`.
+- The Flask app runs on `http://127.0.0.1:5002`.
 - The server uses `instance/playwright_smoke.db`.
 - Playwright launches headless Chrome.
 - Failed tests keep traces, screenshots, and videos.
@@ -653,7 +653,7 @@ PYTHON="./venv/bin/python" ./venv/bin/python -B scripts/run_playwright_server.py
 Then open:
 
 ```text
-http://127.0.0.1:5000/login
+http://127.0.0.1:5002/login
 ```
 
 If the app crashes, fix the Python error shown in the terminal.

--- a/app.py
+++ b/app.py
@@ -182,8 +182,15 @@ class AchievementDefinition:
     target: int
     metric: str
     icon: str
-    tier_thresholds: tuple
-    badge_family: str
+    tier_thresholds: tuple = ()
+    badge_family: str = ""
+
+    def __post_init__(self):
+        if not self.tier_thresholds:
+            self.tier_thresholds = (self.target, self.target, self.target)
+
+        if not self.badge_family:
+            self.badge_family = self.id
 
 
 AGENT_LICENSE_NUMBER = "RZ-74291863"

--- a/migrations/versions/691e1c961990_add_created_at_to_user.py
+++ b/migrations/versions/691e1c961990_add_created_at_to_user.py
@@ -1,0 +1,42 @@
+"""add created_at to user
+
+Revision ID: 691e1c961990
+Revises: 59378b41d041
+Create Date: 2026-05-06 12:12:04.811511
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '691e1c961990'
+down_revision = '59378b41d041'
+branch_labels = None
+depends_on = None
+
+
+def user_columns():
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns("user")}
+
+
+def upgrade():
+    if "created_at" in user_columns():
+        return
+
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('created_at', sa.DateTime(), nullable=True))
+
+    op.execute(sa.text('UPDATE "user" SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL'))
+
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.alter_column('created_at', existing_type=sa.DateTime(), nullable=False)
+
+
+def downgrade():
+    if "created_at" not in user_columns():
+        return
+
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('created_at')

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
     timeout: 15_000,
   },
   use: {
-    baseURL: "http://127.0.0.1:5000",
+    baseURL: "http://127.0.0.1:5002",
     browserName: "chromium",
     channel: browserChannel,
     headless: true,
@@ -36,8 +36,8 @@ export default defineConfig({
   ],
   webServer: {
     command: `${pythonCommand} -B scripts/run_playwright_server.py`,
-    url: "http://127.0.0.1:5000/login",
-    reuseExistingServer: true,
+    url: "http://127.0.0.1:5002/login",
+    reuseExistingServer: false,
     timeout: 120_000,
   },
 });

--- a/scripts/run_playwright_server.py
+++ b/scripts/run_playwright_server.py
@@ -11,10 +11,10 @@ sys.path.insert(0, str(ROOT))
 
 db_path = (INSTANCE_DIR / "playwright_smoke.db").resolve()
 
-os.environ.setdefault("SECRET_KEY", "playwright-smoke-secret-key-for-local-browser-tests")
-os.environ.setdefault("SQLCIPHER_DATABASE_KEY", "playwright-sqlcipher-key-for-local-browser-tests")
-os.environ.setdefault("SAVE_PAYLOAD_KEYS", "v1:cGxheXdyaWdodC1zYXZlLWtleS0zMi1ieXRlcyEhISE")
-os.environ.setdefault("DATABASE_URL", f"sqlite:///{db_path.as_posix()}")
+os.environ["SECRET_KEY"] = "playwright-smoke-secret-key-for-local-browser-tests"
+os.environ["SQLCIPHER_DATABASE_KEY"] = "playwright-sqlcipher-key-for-local-browser-tests"
+os.environ["SAVE_PAYLOAD_KEYS"] = "v1:cGxheXdyaWdodC1zYXZlLWtleS0zMi1ieXRlcyEhISE"
+os.environ["DATABASE_URL"] = f"sqlite:///{db_path.as_posix()}"
 
 subprocess.run(
     [sys.executable, "-m", "flask", "--app", "app.py", "db", "upgrade"],
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     socketio.run(
         app,
         host="127.0.0.1",
-        port=5000,
+        port=5002,
         debug=False,
         use_reloader=False,
         allow_unsafe_werkzeug=True

--- a/tempCodeRunnerFile.py
+++ b/tempCodeRunnerFile.py
@@ -1,11 +1,1 @@
-IGRATION_REQUIRED_TABLES = {
-    "alembic_version",
-    "user",
-    "save_data",
-    "friend",
-    "friend_request",
-    "message",
-    "user_achievement",
-    "profile_reaction",
-    "profile_comment",
-}
+rom cryptography.exceptions import InvalidTag

--- a/templates/main_menu_view.html
+++ b/templates/main_menu_view.html
@@ -30,7 +30,10 @@
         {% endif %}
         <div class="agent-identity">
           <span class="agent-label">AGENT NAME</span>
-          <strong>{{ username }}</strong>
+          <strong class="operator-name">{{ username }}</strong>
+          {% if is_guest %}
+            <span class="mode-chip">GUEST MODE</span>
+          {% endif %}
         </div>
         <img
           src="{{ url_for('static', filename='images/fbi_seal.png') }}"

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -14,7 +14,7 @@ from selenium.webdriver.edge.options import Options as EdgeOptions
 
 
 ROOT = Path(__file__).resolve().parents[2]
-BASE_URL = "http://127.0.0.1:5000"
+BASE_URL = "http://127.0.0.1:5001"
 SELENIUM_CACHE_DIR = Path(tempfile.gettempdir()) / "selenium-manager-cache"
 SELENIUM_CACHE_DIR.mkdir(exist_ok=True)
 os.environ.setdefault("SE_CACHE_PATH", str(SELENIUM_CACHE_DIR))
@@ -77,7 +77,7 @@ def selenium_browser(selenium_server):
             options = ChromeOptions()
             browser_name = "chrome"
 
-        options.page_load_strategy = "none"
+        options.page_load_strategy = "eager"
         options.add_argument("--headless=new")
         options.add_argument("--window-size=1366,768")
         options.add_argument(f"--user-data-dir={profile_dir}")


### PR DESCRIPTION
Summary
Added a defensive migration for user.created_at so fresh and existing databases can upgrade cleanly.
Made achievement definitions backward-compatible by defaulting tier thresholds and badge families when omitted.
Restored main menu test hooks for registered usernames and guest mode display.
Fixed Selenium tests to use the dedicated 5001 test server and wait for deferred page scripts before interacting.
Moved Playwright smoke tests to an isolated 5002 server and forced the test server to use its dedicated smoke-test database.
Updated sanity-check docs to match the new Playwright test port.
Testing
.venv/bin/python sanity_check.py
Result: all selected sanity checks passed.
Notes
This avoids browser tests accidentally hitting a running local dev server on 5000, which was causing misleading failures and missing test database files.

One small heads-up: tempCodeRunnerFile.py is included in the branch diff and looks like an IDE scratch-file change. Worth removing from the PR if it was accidental.