### PR TITLE
Make world chat usernames open public profiles

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -3099,8 +3099,8 @@ a.agent-photo-frame:focus-visible {
 .menu-page .world-chat-modal-panel {
     display: flex;
     flex-direction: column;
-    width: min(680px, calc(100vw - 40px));
-    max-height: min(620px, calc(100vh - 48px));
+    width: min(816px, calc(100vw - 40px));
+    max-height: min(744px, calc(100vh - 48px));
     padding: 20px;
     border: 3px solid #ffffff;
     background: rgba(20, 20, 20, 0.96);
@@ -3172,9 +3172,15 @@ a.agent-photo-frame:focus-visible {
     flex: 1;
     min-height: clamp(220px, 32vh, 320px);
     overflow-y: auto;
-    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 14px;
     border: 2px solid rgba(255, 255, 255, 0.22);
-    background: rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.75);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+    font-family: var(--font-display);
 }
 
 .menu-page .world-chat-empty {
@@ -3184,33 +3190,48 @@ a.agent-photo-frame:focus-visible {
 }
 
 .menu-page .world-chat-message {
-    margin-bottom: 10px;
-    padding: 10px;
-    border: 1px solid rgba(255, 255, 255, 0.16);
-    background: rgba(255, 255, 255, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 100%;
+    max-width: 70%;
+    box-sizing: border-box;
+    padding: 12px 16px;
+    margin: 0;
+    border-radius: 10px;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    word-wrap: break-word;
+    box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.25);
 }
 
-.menu-page .world-chat-message.is-own {
-    border-color: rgba(0, 255, 204, 0.45);
-    background: rgba(0, 255, 204, 0.08);
+.menu-page .world-chat-message.outgoing {
+    background: var(--accent-cyan);
+    color: #1f1f1f;
+    margin-left: auto;
+    text-align: right;
 }
 
-.menu-page .world-chat-message:last-child {
-    margin-bottom: 0;
+.menu-page .world-chat-message.incoming {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-primary);
+    margin-right: auto;
+    text-align: left;
 }
 
 .menu-page .world-chat-message-meta {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 6px;
+    display: block;
     font-size: 0.62rem;
 }
 
 .menu-page .world-chat-message-meta strong,
 .menu-page .world-chat-profile-link {
     color: #00ffcc;
+}
+
+.menu-page .world-chat-message.outgoing .world-chat-message-meta strong,
+.menu-page .world-chat-message.outgoing .world-chat-profile-link {
+    color: rgba(31, 31, 31, 0.82);
 }
 
 .menu-page .world-chat-profile-link {
@@ -3223,15 +3244,8 @@ a.agent-photo-frame:focus-visible {
     text-decoration: underline;
 }
 
-.menu-page .world-chat-message-meta span {
-    color: rgba(255, 255, 255, 0.58);
-    font-family: var(--font-body);
-    letter-spacing: 0;
-}
-
 .menu-page .world-chat-message p {
     margin: 0;
-    color: var(--text-primary);
     font-family: var(--font-body);
     font-size: 0.78rem;
     line-height: 1.35;
@@ -3240,22 +3254,28 @@ a.agent-photo-frame:focus-visible {
     overflow-wrap: anywhere;
 }
 
+.menu-page .world-chat-message time {
+    font-size: 0.58rem;
+    opacity: 0.72;
+}
+
 .menu-page .world-chat-form {
     display: flex;
-    gap: 10px;
+    gap: 12px;
     margin-top: 14px;
 }
 
 .menu-page .world-chat-form input {
     flex: 1;
     min-width: 0;
-    padding: 12px;
-    border: 2px solid rgba(255, 255, 255, 0.28);
-    background: rgba(255, 255, 255, 0.08);
+    padding: 12px 14px;
+    border-radius: 8px;
+    border: var(--panel-border);
+    background: rgba(0, 0, 0, 0.75);
     color: var(--text-primary);
-    font-family: var(--font-body);
+    font-family: var(--font-display);
     font-size: 0.8rem;
-    letter-spacing: 0;
+    letter-spacing: 0.04em;
 }
 
 .menu-page .world-chat-form input::placeholder {

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -3208,8 +3208,19 @@ a.agent-photo-frame:focus-visible {
     font-size: 0.62rem;
 }
 
-.menu-page .world-chat-message-meta strong {
+.menu-page .world-chat-message-meta strong,
+.menu-page .world-chat-profile-link {
     color: #00ffcc;
+}
+
+.menu-page .world-chat-profile-link {
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.menu-page .world-chat-profile-link:hover,
+.menu-page .world-chat-profile-link:focus-visible {
+    text-decoration: underline;
 }
 
 .menu-page .world-chat-message-meta span {

--- a/static/js/world-chat.js
+++ b/static/js/world-chat.js
@@ -8,6 +8,7 @@ const worldChatForm = document.querySelector("[data-world-chat-form]");
 const worldChatInput = document.querySelector("[data-world-chat-input]");
 const worldChatSubmit = document.querySelector("[data-world-chat-submit]");
 const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content") || "";
+const canViewProfiles = Number(document.body?.dataset.userId || 0) > 0;
 
 let worldChatPollTimer = null;
 let worldChatIsOpen = false;
@@ -43,6 +44,17 @@ function formatWorldChatTime(timestamp) {
   });
 }
 
+function buildWorldChatAuthorMarkup(message) {
+  const safeName = escapeHtml(message.display_name || "Unknown Agent");
+  const authorUserId = Number(message.user_id);
+
+  if (canViewProfiles && Number.isInteger(authorUserId) && authorUserId > 0) {
+    return `<a class="world-chat-profile-link" href="/profile/${authorUserId}">${safeName}</a>`;
+  }
+
+  return `<strong>${safeName}</strong>`;
+}
+
 function renderWorldChatMessages(messages) {
   if (!worldChatMessages) {
     return;
@@ -55,14 +67,14 @@ function renderWorldChatMessages(messages) {
 
   worldChatMessages.innerHTML = messages.map((message) => {
     const ownClass = message.is_current_user ? " is-own" : "";
-    const safeName = escapeHtml(message.display_name || "Unknown Agent");
+    const authorMarkup = buildWorldChatAuthorMarkup(message);
     const safeText = escapeHtml(message.message || "");
     const safeTime = escapeHtml(formatWorldChatTime(message.created_at));
 
     return `
       <article class="world-chat-message${ownClass}">
         <div class="world-chat-message-meta">
-          <strong>${safeName}</strong>
+          ${authorMarkup}
           <span>${safeTime}</span>
         </div>
         <p>${safeText}</p>

--- a/static/js/world-chat.js
+++ b/static/js/world-chat.js
@@ -9,6 +9,7 @@ const worldChatInput = document.querySelector("[data-world-chat-input]");
 const worldChatSubmit = document.querySelector("[data-world-chat-submit]");
 const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content") || "";
 const canViewProfiles = Number(document.body?.dataset.userId || 0) > 0;
+const WORLD_CHAT_MAX_LINES = 1;
 
 let worldChatPollTimer = null;
 let worldChatIsOpen = false;
@@ -55,6 +56,22 @@ function buildWorldChatAuthorMarkup(message) {
   return `<strong>${safeName}</strong>`;
 }
 
+function countWorldChatLines(message) {
+  if (!message) {
+    return 0;
+  }
+
+  return String(message).split(/\r\n|\r|\n/).length;
+}
+
+function validateWorldChatDraft(message) {
+  if (countWorldChatLines(message) > WORLD_CHAT_MAX_LINES) {
+    return "World chat only supports one line at a time.";
+  }
+
+  return null;
+}
+
 function renderWorldChatMessages(messages) {
   if (!worldChatMessages) {
     return;
@@ -66,23 +83,43 @@ function renderWorldChatMessages(messages) {
   }
 
   worldChatMessages.innerHTML = messages.map((message) => {
-    const ownClass = message.is_current_user ? " is-own" : "";
+    const messageVariantClass = message.is_current_user ? "outgoing" : "incoming";
     const authorMarkup = buildWorldChatAuthorMarkup(message);
     const safeText = escapeHtml(message.message || "");
     const safeTime = escapeHtml(formatWorldChatTime(message.created_at));
+    const safeDateTime = escapeHtml(message.created_at || "");
 
     return `
-      <article class="world-chat-message${ownClass}">
+      <article class="world-chat-message ${messageVariantClass}">
         <div class="world-chat-message-meta">
           ${authorMarkup}
-          <span>${safeTime}</span>
         </div>
         <p>${safeText}</p>
+        <time datetime="${safeDateTime}">${safeTime}</time>
       </article>
     `;
   }).join("");
 
   worldChatMessages.scrollTop = worldChatMessages.scrollHeight;
+}
+
+async function parseWorldChatResponse(response, fallbackMessage) {
+  const responseText = await response.text();
+  let payload = null;
+
+  if (responseText) {
+    try {
+      payload = JSON.parse(responseText);
+    } catch (_error) {
+      payload = null;
+    }
+  }
+
+  if (!response.ok || !payload || !payload.ok) {
+    throw new Error(payload?.message || fallbackMessage);
+  }
+
+  return payload;
 }
 
 async function loadWorldChatMessages() {
@@ -101,11 +138,7 @@ async function loadWorldChatMessages() {
       credentials: "same-origin",
     });
 
-    const payload = await response.json();
-
-    if (!response.ok || !payload.ok) {
-      throw new Error(payload.message || "Unable to load world chat.");
-    }
+    const payload = await parseWorldChatResponse(response, "Unable to load world chat.");
 
     renderWorldChatMessages(payload.messages || []);
     setWorldChatStatus("World chat is live.", "online");
@@ -161,7 +194,16 @@ async function handleWorldChatSubmit(event) {
     return;
   }
 
-  const message = worldChatInput.value.trim();
+  const rawMessage = worldChatInput.value;
+  const draftError = validateWorldChatDraft(rawMessage);
+
+  if (draftError) {
+    setWorldChatStatus(draftError, "error");
+    worldChatInput.focus();
+    return;
+  }
+
+  const message = rawMessage.trim();
 
   if (!message) {
     setWorldChatStatus("Message cannot be empty.", "error");
@@ -184,11 +226,7 @@ async function handleWorldChatSubmit(event) {
       body: JSON.stringify({ message }),
     });
 
-    const payload = await response.json();
-
-    if (!response.ok || !payload.ok) {
-      throw new Error(payload.message || "Unable to send message.");
-    }
+    const payload = await parseWorldChatResponse(response, "Unable to send message.");
 
     worldChatInput.value = "";
     setWorldChatStatus("Message sent.", "online");
@@ -227,4 +265,15 @@ if (worldChatToggle && worldChatModal && worldChatPanel) {
   });
 
   worldChatForm?.addEventListener("submit", handleWorldChatSubmit);
+  worldChatInput?.addEventListener("paste", (event) => {
+    const pastedText = event.clipboardData?.getData("text") || "";
+    const draftError = validateWorldChatDraft(pastedText);
+
+    if (!draftError) {
+      return;
+    }
+
+    event.preventDefault();
+    setWorldChatStatus(draftError, "error");
+  });
 }

--- a/tests/playwright/social-progress.spec.js
+++ b/tests/playwright/social-progress.spec.js
@@ -380,6 +380,7 @@ test("profiles support reactions comments and custom backgrounds", async ({ brow
     await secondContext.close();
   }
 });
+
 test("world chat usernames link to public profiles", async ({ browser, page }) => {
   const secondContext = await browser.newContext();
   const secondPage = await secondContext.newPage();
@@ -394,10 +395,12 @@ test("world chat usernames link to public profiles", async ({ browser, page }) =
     const secondUserId = await secondPage.locator("body").getAttribute("data-user-id");
 
     await sendWorldChatMessage(secondPage, worldChatMessage);
+    await expect(secondPage.locator(".world-chat-message.outgoing", { hasText: worldChatMessage })).toBeVisible();
 
     await page.goto("/main_menu");
     await openWorldChat(page);
     await expect(page.locator("[data-world-chat-messages]")).toContainText(worldChatMessage);
+    await expect(page.locator(".world-chat-message.incoming", { hasText: worldChatMessage })).toBeVisible();
 
     const profileLink = page
       .locator("[data-world-chat-messages]")
@@ -413,4 +416,3 @@ test("world chat usernames link to public profiles", async ({ browser, page }) =
     await secondContext.close();
   }
 });
-

--- a/tests/playwright/social-progress.spec.js
+++ b/tests/playwright/social-progress.spec.js
@@ -119,6 +119,18 @@ async function sendFriendRequest(page, friendUsername) {
   await expect(page).toHaveURL(/\/friends$/);
 }
 
+async function openWorldChat(page) {
+  await page.locator("[data-world-chat-toggle]").click();
+  await expect(page.locator("[data-world-chat-panel]")).toBeVisible();
+}
+
+async function sendWorldChatMessage(page, message) {
+  await openWorldChat(page);
+  await page.locator("[data-world-chat-input]").fill(message);
+  await page.locator("[data-world-chat-form]").getByRole("button", { name: "Send" }).click();
+  await expect(page.locator("[data-world-chat-messages]")).toContainText(message);
+}
+
 async function acceptFriendRequest(page, username) {
   await page.goto("/friends");
   const requestItem = page.locator("li", { hasText: username }).first();
@@ -368,3 +380,37 @@ test("profiles support reactions comments and custom backgrounds", async ({ brow
     await secondContext.close();
   }
 });
+test("world chat usernames link to public profiles", async ({ browser, page }) => {
+  const secondContext = await browser.newContext();
+  const secondPage = await secondContext.newPage();
+  const firstUser = uniqueCredentials("worldprofileone");
+  const secondUser = uniqueCredentials("worldprofiletwo");
+  const worldChatMessage = `profile-link-${Date.now()}`;
+
+  try {
+    await registerAndLogin(page, firstUser);
+    await registerAndLogin(secondPage, secondUser);
+
+    const secondUserId = await secondPage.locator("body").getAttribute("data-user-id");
+
+    await sendWorldChatMessage(secondPage, worldChatMessage);
+
+    await page.goto("/main_menu");
+    await openWorldChat(page);
+    await expect(page.locator("[data-world-chat-messages]")).toContainText(worldChatMessage);
+
+    const profileLink = page
+      .locator("[data-world-chat-messages]")
+      .getByRole("link", { name: secondUser.username })
+      .first();
+
+    await expect(profileLink).toHaveAttribute("href", `/profile/${secondUserId}`);
+    await profileLink.click();
+
+    await expect(page).toHaveURL(new RegExp(`/profile/${secondUserId}$`));
+    await expect(page.locator(".public-profile-heading")).toContainText(secondUser.username);
+  } finally {
+    await secondContext.close();
+  }
+});
+


### PR DESCRIPTION
## Summary
This PR improves the world chat experience by making usernames open public profiles and updating the chat modal to follow the direct friend-chat layout more closely.

## What Changed
- made world chat usernames clickable for logged-in users
- linked usernames to the sender's public profile
- updated world chat bubbles to match direct chat more closely
- styled outgoing messages as cyan right-aligned bubbles
- styled incoming messages as light left-aligned bubbles
- stretched message boxes so they no longer collapse into tiny tiles
- enlarged the world chat popup by about 20%
- added simple client-side validation to block multiline world chat messages

